### PR TITLE
Feature/buffs

### DIFF
--- a/js/data/buffs.js
+++ b/js/data/buffs.js
@@ -1,9 +1,17 @@
+const BOK = {
+  name: 'Greater Blessing of Kings',
+  id: 25898,
+  icon: 'spell_magic_greaterblessingofkings',
+}
+
+const WF = {
+  name: 'Windfury Totem',
+  id: 25587,
+  icon: 'spell_nature_windfury'
+}
+
 const BUFFS = [
-  {
-    name: 'Greater Blessing of Kings',
-    id: 25898,
-    icon: 'spell_magic_greaterblessingofkings'
-  },
+  BOK,
   {
     name: 'Greater Blessing of Might',
     id: 27141,
@@ -75,11 +83,7 @@ const BUFFS = [
       MP5: 50
     }
   },
-  {
-    name: 'Windfury Totem',
-    id: 25587,
-    icon: 'spell_nature_windfury'
-  },
+  WF,
   {
     name: 'Arcane Brilliance',
     id: 27127,
@@ -130,7 +134,7 @@ const BUFFS = [
 ]
 
 function getStatsFromBuffs(buffs) {
-  return buffs.reduce((stats, buffData) => {
+  return buffs.reduce(({stats, talents}, buffData) => {
     let buffId = buffData
     let isImproved = false
 
@@ -139,30 +143,17 @@ function getStatsFromBuffs(buffs) {
       buffId = buffData.id
     }
 
-    const buff = BUFFS.find(buff => buffId === buff.id)
-    if (!buff) throw Error(`Detected invalid buff id ${id}`)
+    if (buffId === BOK.id) talents.kingsMod = 1.1
+    else if (buffId === WF.id) talents.windfury = 1
+    else {
+      const buff = BUFFS.find(buff => buffId === buff.id)
+      if (!buff) throw Error(`Detected invalid buff id ${id}`)
 
-    const ratio = isImproved ? buff.improve_ratio || 1 : 1
-    if (buff.stats)
-      Object.entries(buff.stats).forEach(([stat, amount]) => stats[stat] = (stats[stat] || 0) + amount * ratio)
+      const ratio = isImproved ? buff.improve_ratio || 1 : 1
+      if (buff.stats)
+        Object.entries(buff.stats).forEach(([stat, amount]) => stats[stat] = (stats[stat] || 0) + amount * ratio)
+    }
 
-    return stats
-  }, {})
+    return { stats, talents }
+  }, { stats: {}, talents: { kingsMod: 1, windfury: 0 } })
 }
-
-const result = getStatsFromBuffs([
-  25898,
-  { id: 27141, improved: true },
-  { id: 27143, improved: true },
-  17007,
-  { id: 25359, improved: true },
-  { id: 25528, improved: true },
-  25570,
-  27127,
-  { id: 26991, improved: true },
-  { id: 25392, improved: true },
-  { id: 27268, improved: false },
-  6562
-])
-
-console.log(result)

--- a/js/data/buffs.js
+++ b/js/data/buffs.js
@@ -1,0 +1,168 @@
+const BUFFS = [
+  {
+    name: 'Greater Blessing of Kings',
+    id: 25898,
+    icon: 'spell_magic_greaterblessingofkings'
+  },
+  {
+    name: 'Greater Blessing of Might',
+    id: 27141,
+    icon: 'spell_holy_greaterblessingofkings',
+    improve_ratio: 1.2,
+    stats: {
+      MAP: 220,
+      RAP: 220,
+    }
+  },
+  {
+    name: 'Greater Blessing of Wisdom',
+    id: 27143,
+    icon: 'spell_holy_greaterblessingofwisdom',
+    improve_ratio: 1.2,
+    stats: {
+      MP5: 41
+    }
+  },
+  {
+    name: 'Battle Shout',
+    id: 2048,
+    icon: 'ability_warrior_battleshout',
+    improve_ratio: 1.25,
+    stats: {
+      MAP: 306
+    }
+  },
+  {
+    name: 'Trueshot Aura',
+    id: 27066,
+    icon: 'ability_trueshot',
+    stats: {
+      MAP: 125,
+      RAP: 125
+    }
+  },
+  {
+    name: 'Leader of the Pack',
+    id: 17007,
+    icon: 'spell_nature_unyeildingstamina',
+    stats: {
+      CritChance: 5
+    }
+  },
+  {
+    name: 'Grace of Air Totem',
+    id: 25359,
+    icon: 'spell_nature_invisibilitytotem',
+    improve_ratio: 1.15,
+    stats: {
+      Agi: 77
+    }
+  },
+  {
+    name: 'Strength of Earth Totem',
+    id: 25528,
+    icon: 'spell_nature_earthbindtotem',
+    improve_ratio: 1.15,
+    stats: {
+      Str: 86
+    }
+  },
+  {
+    name: 'Mana Spring Totem',
+    id: 25570,
+    icon: 'spell_nature_manaregentotem',
+    stats: {
+      MP5: 50
+    }
+  },
+  {
+    name: 'Windfury Totem',
+    id: 25587,
+    icon: 'spell_nature_windfury'
+  },
+  {
+    name: 'Arcane Brilliance',
+    id: 27127,
+    icon: 'spell_holy_arcaneintellect',
+    stats: {
+      Int: 40
+    }
+  },
+  {
+    name: 'Gift of the Wild',
+    id: 26991,
+    icon: 'spell_nature_giftofthewild',
+    improve_ratio: 1.35,
+    stats: {
+      Str: 14,
+      Agi: 14,
+      Stam: 14,
+      Int: 14,
+      Spi: 14
+    }
+  },
+  {
+    name: 'Prayer of Fortitude',
+    id: 25392,
+    icon: 'spell_holy_prayeroffortitude',
+    improve_ratio: 1.3,
+    stats: {
+      Stam: 79
+    }
+  },
+  {
+    name: 'Blood Pact',
+    id: 27268,
+    icon: 'spell_shadow_bloodboil',
+    improve_ratio: 1.3,
+    stats: {
+      Stam: 70
+    }
+  },
+  {
+    name: 'Heroic Presence',
+    id: 6562,
+    icon: 'inv_helmet_21',
+    stats: {
+      HitChance: 1
+    }
+  },
+]
+
+function getStatsFromBuffs(buffs) {
+  return buffs.reduce((stats, buffData) => {
+    let buffId = buffData
+    let isImproved = false
+
+    if (typeof buffData === 'object') {
+      isImproved = buffData.improved
+      buffId = buffData.id
+    }
+
+    const buff = BUFFS.find(buff => buffId === buff.id)
+    if (!buff) throw Error(`Detected invalid buff id ${id}`)
+
+    const ratio = isImproved ? buff.improve_ratio || 1 : 1
+    if (buff.stats)
+      Object.entries(buff.stats).forEach(([stat, amount]) => stats[stat] = (stats[stat] || 0) + amount * ratio)
+
+    return stats
+  }, {})
+}
+
+const result = getStatsFromBuffs([
+  25898,
+  { id: 27141, improved: true },
+  { id: 27143, improved: true },
+  17007,
+  { id: 25359, improved: true },
+  { id: 25528, improved: true },
+  25570,
+  27127,
+  { id: 26991, improved: true },
+  { id: 25392, improved: true },
+  { id: 27268, improved: false },
+  6562
+])
+
+console.log(result)


### PR DESCRIPTION
Added buffs module.

This module exposes a **getStatsFromBuffs* formula. This function expects an array of the buffs the player currently has active. The buffs can be represented by one of the following:
- A number equal to the ID of the used buff.
- An object with the following schema:
```
{
    id: Number equal to the ID of the buff.
    improved: Indicates if the improved version of the buff is going to be used.
}
```

This is an example of how to use it:

```js
const result = getStatsFromBuffs([
  25898,
  { id: 27141, improved: true },
  { id: 27143, improved: true },
  17007,
  { id: 25359, improved: true },
  { id: 25528, improved: true },
  25570,
  27127,
  { id: 26991, improved: true },
  { id: 25392, improved: true },
  { id: 27268, improved: false },
  25587,
  6562
])

console.log(result)
```

Which returns:
```
{
  stats: {
    MAP: 264,
    RAP: 264,
    MP5: 99.19999999999999,
    CritChance: 5,
    Agi: 107.45,
    Str: 117.8,
    Int: 58.900000000000006,
    Stam: 191.60000000000002,
    Spi: 18.900000000000002,
    HitChance: 1
  },
  talents: { kingsMod: 1.1, windfury: true }
}
```

The stats object represents raw stats to be added to the base stats of the character.
The talents object contains stuff that doesn't really fit in the "raw stats" description, and will be used over the code.
The talents object will always have:
- kingsMod: Which will be 1.1 if BoK is active, and 1.0 if it's inactive.
- windfury: which will be true if WF is active, and false if it's not.


Buffs can also be obtained from the BUFFS array. A buff has the following schema:
- name: Official name of the buff.
- id: Spell id of the buff
- icon: Icon name so it can be represented in frontend.
- stats: Optional. If existing, shows how that specific buff affects the player stats.