### PR TITLE
Feature/buffs

### DIFF
--- a/js/data/buffs.js
+++ b/js/data/buffs.js
@@ -1,102 +1,92 @@
-const BOK = {
-  name: 'Greater Blessing of Kings',
-  id: 25898,
-  icon: 'spell_magic_greaterblessingofkings',
-}
+const BOK_ID = 25898
+const WF_ID = 25587
+const IMP_SANC_AURA_ID = 31870
 
-const WF = {
-  name: 'Windfury Totem',
-  id: 25587,
-  icon: 'spell_nature_windfury'
-}
-
-const BUFFS = [
-  BOK,
-  {
+const BUFFS = {
+  [BOK_ID]: {
+    name: 'Greater Blessing of Kings',
+    icon: 'spell_magic_greaterblessingofkings',
+  },
+  27141: {
     name: 'Greater Blessing of Might',
-    id: 27141,
     icon: 'spell_holy_greaterblessingofkings',
-    improve_ratio: 1.2,
+    talented_ratio: 1.2,
     stats: {
       MAP: 220,
       RAP: 220,
     }
   },
-  {
+  27143: {
     name: 'Greater Blessing of Wisdom',
-    id: 27143,
     icon: 'spell_holy_greaterblessingofwisdom',
-    improve_ratio: 1.2,
+    talented_ratio: 1.2,
     stats: {
       MP5: 41
     }
   },
-  {
+  2048: {
     name: 'Battle Shout',
-    id: 2048,
     icon: 'ability_warrior_battleshout',
-    improve_ratio: 1.25,
+    t2_3p_bonus: 30,
+    solarian_sapphire_bonus: 70,
+    talented_ratio: 1.25,
     stats: {
       MAP: 306
     }
   },
-  {
+  27077: {
     name: 'Trueshot Aura',
-    id: 27066,
     icon: 'ability_trueshot',
     stats: {
       MAP: 125,
       RAP: 125
     }
   },
-  {
+  17007: {
     name: 'Leader of the Pack',
-    id: 17007,
     icon: 'spell_nature_unyeildingstamina',
     stats: {
       CritChance: 5
     }
   },
-  {
+  25359: {
     name: 'Grace of Air Totem',
-    id: 25359,
     icon: 'spell_nature_invisibilitytotem',
-    improve_ratio: 1.15,
+    talented_ratio: 1.15,
     stats: {
       Agi: 77
     }
   },
-  {
+  25528: {
     name: 'Strength of Earth Totem',
-    id: 25528,
     icon: 'spell_nature_earthbindtotem',
-    improve_ratio: 1.15,
+    talented_ratio: 1.15,
     stats: {
       Str: 86
     }
   },
-  {
+  25570: {
     name: 'Mana Spring Totem',
-    id: 25570,
     icon: 'spell_nature_manaregentotem',
     stats: {
       MP5: 50
     }
   },
-  WF,
-  {
+  [WF_ID] : {
+    name: 'Windfury Totem',
+    icon: 'spell_nature_windfury'
+  },
+  27127: {
     name: 'Arcane Brilliance',
-    id: 27127,
     icon: 'spell_holy_arcaneintellect',
     stats: {
       Int: 40
     }
   },
-  {
+  26991: {
     name: 'Gift of the Wild',
-    id: 26991,
     icon: 'spell_nature_giftofthewild',
-    improve_ratio: 1.35,
+    talented_ratio: 1.35,
     stats: {
       Str: 14,
       Agi: 14,
@@ -105,55 +95,63 @@ const BUFFS = [
       Spi: 14
     }
   },
-  {
+  25392: {
     name: 'Prayer of Fortitude',
-    id: 25392,
     icon: 'spell_holy_prayeroffortitude',
-    improve_ratio: 1.3,
+    talented_ratio: 1.3,
     stats: {
       Stam: 79
     }
   },
-  {
+  27268: {
     name: 'Blood Pact',
-    id: 27268,
     icon: 'spell_shadow_bloodboil',
-    improve_ratio: 1.3,
+    talented_ratio: 1.3,
     stats: {
       Stam: 70
     }
   },
-  {
+  [IMP_SANC_AURA_ID] : {
+    name: 'Improved Sanctity Aura',
+    icon: 'spell_holy_mindvision'
+  },
+  6562: {
     name: 'Heroic Presence',
-    id: 6562,
     icon: 'inv_helmet_21',
     stats: {
       HitChance: 1
     }
   },
-]
+}
 
 function getStatsFromBuffs(buffs) {
   return buffs.reduce(({stats, talents}, buffData) => {
     let buffId = buffData
-    let isImproved = false
+    let props = {}
 
-    if (typeof buffData === 'object') {
-      isImproved = buffData.improved
-      buffId = buffData.id
-    }
+    if (typeof buffData === 'object')
+      ({ id: buffId, ...props } = buffData)
 
-    if (buffId === BOK.id) talents.kingsMod = 1.1
-    else if (buffId === WF.id) talents.windfury = 1
+    if (buffId === BOK_ID) talents.kingsMod += 10/100
+    else if (buffId === WF_ID) talents.windfury = true
+    else if (buffId === IMP_SANC_AURA_ID) talents.impSancAura += 2/100
     else {
-      const buff = BUFFS.find(buff => buffId === buff.id)
-      if (!buff) throw Error(`Detected invalid buff id ${id}`)
+      if (!BUFFS[buffId]) throw Error(`Detected invalid buff id ${id}`)
+      const buff = BUFFS[buffId]
 
-      const ratio = isImproved ? buff.improve_ratio || 1 : 1
+      let bonus = 0
+      let ratio = 1
+      Object.entries(props).forEach(([name, value]) => {
+        if (!value) return;
+        if (buff[name + "_bonus"]) bonus += buff[name + "_bonus"]
+        else if (buff[name + "_ratio"]) ratio *= buff[name + "_ratio"]
+        else throw Error(`Detected invalid property "${name}" for buff "${buff.name}"`)
+      })
+
       if (buff.stats)
-        Object.entries(buff.stats).forEach(([stat, amount]) => stats[stat] = (stats[stat] || 0) + amount * ratio)
+        Object.entries(buff.stats).forEach(([stat, amount]) => stats[stat] = (stats[stat] || 0) + (amount + bonus)* ratio)
     }
 
     return { stats, talents }
-  }, { stats: {}, talents: { kingsMod: 1, windfury: 0 } })
+  }, { stats: {}, talents: { impSancAura: 1, kingsMod: 1, windfury: false } })
 }

--- a/js/data/buffs.js
+++ b/js/data/buffs.js
@@ -125,12 +125,17 @@ const BUFFS = {
 }
 
 function getStatsFromBuffs(buffs) {
+  const usedBuffs = {}
+
   return buffs.reduce(({stats, talents}, buffData) => {
     let buffId = buffData
     let props = {}
 
     if (typeof buffData === 'object')
       ({ id: buffId, ...props } = buffData)
+
+    if (usedBuffs[buffId]) throw Error(`Buff with ID ${buffId} is being used more than once!`)
+    usedBuffs[buffId] = true
 
     if (buffId === BOK_ID) talents.kingsMod += 10/100
     else if (buffId === WF_ID) talents.windfury = true

--- a/js/data/buffs.js
+++ b/js/data/buffs.js
@@ -34,7 +34,7 @@ const BUFFS = {
       MAP: 306
     }
   },
-  27077: {
+  27066: {
     name: 'Trueshot Aura',
     icon: 'ability_trueshot',
     stats: {

--- a/js/data/consumables.js
+++ b/js/data/consumables.js
@@ -1,33 +1,29 @@
-const FOODS = [
-  {
+const FOODS = {
+  33292: {
     name: 'Blackened Sporefish',
-    id: 33292,
     icon: 'inv_misc_food_79',
     stats: {
       Stam: 20,
       MP5: 8,
     },
   },
-  {
+  27664: {
     name: 'Grilled Mudfish',
-    id: 27664,
     icon: 'inv_misc_food_78',
     stats: {
       Spi: 20,
       Agi: 20
     }
   },
-  {
+  13928: {
     name: 'Grilled Squid',
-    id: 13928,
     icon: 'inv_misc_fish_13',
     stats: {
       Agi: 10
     }
   },
-  {
+  27655: {
     name: 'Ravager Dog',
-    id: 27655,
     icon: 'inv_misc_food_53',
     stats: {
       Spi: 20,
@@ -35,75 +31,67 @@ const FOODS = [
       RAP: 40
     }
   },
-  {
+  27667: {
     name: 'Spicy Crawdad',
-    id: 27667,
     icon: 'inv_misc_fish_16',
     stats: {
       Sta: 30,
       Spi: 20
     }
   },
-  {
+  33872: {
     name: 'Spicy Hot Talbuk',
-    id: 33872,
     icon: 'inv_misc_food_84_roastclefthoof',
     stats: {
       Spi: 20,
       Hit: 20
     }
   },
-  {
+  27660: {
     name: 'Talbuk Steak',
-    id: 27660,
     icon: 'inv_misc_food_84_roastclefthoof',
     stats: {
       Stam: 20,
       Spi: 20
     }
   },
-  {
+  27659: {
     name: 'Warp Burger',
-    id: 27659,
     icon: 'inv_misc_food_65',
     stats: {
       Spi: 20,
       Agi: 20
     }
   }
-]
+}
 
-const BATTLE_ELIXIRS = [
-  {
+const BATTLE_ELIXIRS = {
+  9224: {
     name: 'Elixir of Demonslaying',
-    id: 9224,
     icon: 'inv_potion_27',
     stats: {
       MAP: 265,
       RAP: 265
     }
   },
-  {
+  22831: {
     name: 'Elixir of Major Agility',
-    id: 22831,
     icon: 'inv_potion_127',
     stats: {
       Agi: 35,
       Crit: 20
     }
   },
-  {
+  13452: {
     name: 'Elixir of the Mongoose',
-    id: 13452,
     icon: 'inv_potion_32',
     stats: {
       Agi: 25,
       Crit: 28
     }
   },
-  {
+  31679: {
     name: 'Fel Strength Elixir',
-    id: 31679,
     icon: 'inv_potion_152',
     stats: {
       Stam: -10,
@@ -111,34 +99,30 @@ const BATTLE_ELIXIRS = [
       RAP: 90
     }
   },
-  {
+  28102: {
     name: 'Onslaught Elixir',
-    id: 28102,
     icon: 'inv_potion_58',
     stats: {
       MAP: 60,
       RAP: 60
     }
   },
-  {
+  9187: {
     name: 'Elixir of Greater Agility',
-    id: 9187,
     icon: 'inv_potion_94',
     stats: {
       Agi: 25
     }
   },
-  {
+  8949: {
     name: 'Elixir of Agility',
-    id: 8949,
     icon: 'inv_potion_93',
     stats: {
       Agi: 15
     }
   },
-  {
+  28104: {
     name: 'Elixir of Mastery',
-    id: 28104,
     icon: 'inv_potion_111',
     stats: {
       Str: 15,
@@ -148,105 +132,94 @@ const BATTLE_ELIXIRS = [
       Spi: 15
     }
   }
-]
+}
 
-const GUARDIAN_ELIXIRS = [
-  {
+const GUARDIAN_ELIXIRS = {
+  22840: {
     name: 'Elixir of Major Mageblood',
-    id: 22840,
     icon: 'inv_potion_151',
     stats: {
       MP5: 16
     }
   },
-  {
+  32067: {
     name: 'Elixir of Draenic Wisdom',
-    id: 32067,
     icon: 'inv_potion_155',
     stats: {
       Int: 30,
       Spi: 30
     }
   },
-  {
+  20007: {
     name: 'Mageblood Potion',
-    id: 20007,
     icon: 'inv_potion_45',
     stats: {
       MP5: 12
     }
   },
-  {
+  9179: {
     name: 'Elixir of Greater Intellect',
-    id: 9179,
     icon: 'inv_potion_10',
     stats: {
       Int: 25
     }
   },
-  {
+  32062: {
     name: 'Elixir of Major Fortitude',
-    id: 32062,
     icon: 'inv_potion_158',
     stats: {
       Health: 250,
       HP5: 10
     }
   },
-  {
+  3825: {
     name: 'Elixir of Fortitude',
-    id: 3825,
     icon: 'inv_potion_43',
     stats: {
       Health: 120
     }
   }
-]
+}
 
-const FLASKS = [
-  {
+const FLASKS = {
+  13511: {
     name: 'Flask of Distilled Wisdom',
-    id: 13511,
     icon: 'inv_potion_97',
     stats: {
       Int: 65
     }
   },
-  {
+  22851: {
     name: 'Flask of Fortification',
-    id: 22851,
     icon: 'inv_potion_119',
     stats: {
       Health: 500
     }
   },
-  {
+  22853: {
     name: 'Flask of Mighty Restoration',
-    id: 22853,
     icon: 'inv_potion_118',
     stats: {
       MP5: 25
     }
   },
-  {
+  22854: {
     name: 'Flask of Relentless Assault',
-    id: 22854,
     icon: 'inv_potion_117',
     stats: {
       MAP: 120,
       RAP: 120
     }
-  },  {
+  },
+  13510: {
     name: 'Flask of the Titans',
-    id: 13510,
     icon: 'inv_potion_62',
     stats: {
       Health: 400
     }
   },
-  {
+  32599: {
     name: 'Unstable Flask of the Bandit',
-    id: 32599,
     icon: 'inv_potion_91',
     stats: {
       Agi: 20,
@@ -255,114 +228,102 @@ const FLASKS = [
       Stam: 30
     }
   }
-]
+}
 
-const SCROLLS_OF_AGILITY = [
-  {
+const SCROLLS_OF_AGILITY = {
+  3012: {
     name: 'Scroll of Agility I',
-    id: 3012,
     icon: 'inv_scroll_02',
     stats: {
       Agi: 5
     }
   },
-  {
+  1477: {
     name: 'Scroll of Agility II',
-    id: 1477,
     icon: 'inv_scroll_02',
     stats: {
       Agi: 9
     }
   },
-  {
+  4425: {
     name: 'Scroll of Agility III',
-    id: 4425,
     icon: 'inv_scroll_02',
     stats: {
       Agi: 13
     }
   },
-  {
+  10309: {
     name: 'Scroll of Agility IV',
-    id: 10309,
     icon: 'inv_scroll_02',
     stats: {
       Agi: 17
     }
   },
-  {
+  27498: {
     name: 'Scroll of Agility V',
-    id: 27498,
     icon: 'inv_scroll_02',
     stats: {
       Agi: 20
     }
   }
-]
+}
 
-const SCROLLS_OF_STRENGTH = [
-  {
+const SCROLLS_OF_STRENGTH = {
+  954: {
     name: 'Scroll of Strength I',
-    id: 954,
     icon: 'inv_scroll_02',
     stats: {
       Str: 5
     }
   },
-  {
+  2289: {
     name: 'Scroll of Strength II',
-    id: 2289,
     icon: 'inv_scroll_02',
     stats: {
       Str: 9
     }
   },
-  {
+  4426: {
     name: 'Scroll of Strength III',
-    id: 4426,
     icon: 'inv_scroll_02',
     stats: {
       Str: 13
     }
   },
-  {
+  10310: {
     name: 'Scroll of Strength IV',
-    id: 10310,
     icon: 'inv_scroll_02',
     stats: {
       Str: 17
     }
   },
-  {
+  27503: {
     name: 'Scroll of Strength V',
-    id: 27503,
     icon: 'inv_scroll_02',
     stats: {
       Str: 20
     }
   }
-]
+}
 
-const PET_FOODS = [
-  {
+const PET_FOODS = {
+  33874: {
     name: "Kibler's Bits",
-    id: 33874,
     icon: 'inv_misc_food_49',
     stats: {
       Str: 20,
       Spi: 20
     }
   },
-  {
+  27656: {
     name: 'Sporeling Snack',
-    id: 27656,
     icon: 'inv_misc_food_87_sporelingsnack',
     stats: {
       Stam: 20,
       Spi: 20
     }
   }
-]
+}
 
 const PLAYER_CONSUMABLES = {
   food: FOODS,
@@ -382,10 +343,9 @@ const PET_CONSUMABLES = {
 function getStatsFromConsumes(consumables, source) {
   return Object.entries(consumables).reduce((stats, [type, id]) => {
     if (!source[type]) throw Error(`Detected invalid consumable of type "${type}"`)
-    const consume = source[type].find(consume => id === consume.id)
-    if (!consume) throw Error(`Detected invalid consume id ${id}`)
+    if (!source[type][id]) throw Error(`Detected invalid consume id ${id}`)
 
-    Object.entries(consume.stats).forEach(([stat, amount]) => stats[stat] = (stats[stat] || 0) + amount)
+    Object.entries(source[type][id].stats).forEach(([stat, amount]) => stats[stat] = (stats[stat] || 0) + amount)
 
     return stats
   }, {})


### PR DESCRIPTION
Changed consumables and buffs data structures, from an array to an object where id is the key (it's just better, and also more consistent with how gear data will look).

Added Improved aura of sanctity and battle shout bonuses.
The buff object can now define different modifiers, for example battle shout looks like this:
```js
{
  2048: {
    name: 'Battle Shout',
    icon: 'ability_warrior_battleshout',
    t2_3p_bonus: 30,
    solarian_sapphire_bonus: 70,
    talented_ratio: 1.25,
    stats: {
      MAP: 306
    }
}
 ```
 
 Modifiers must end with "_bonus" or "_ratio", where bonuses are flat increases and ratio are % increases.
 The current logic is: get the base value, add the bonus (defaults to 0) and then multiply by the ratio (defaults to 1).
 
 Player buffs now look like this:
 ```js
  { id: 2048, talented: false, t2_3p: true, solarian_sapphire: true }
```
Where each property other than id is used to find bonuses and ratios.
It should to, given a definition of a buff, detect those properties that end with _bonus/_ratio and add a checkbox for them, which then can be used to create the buff object to be sent to the buff calculator.
