### PR TITLE
Minor fixes - naaru, pet combat log and pet cds from previous loop

### DIFF
--- a/js/auras.js
+++ b/js/auras.js
@@ -161,7 +161,10 @@ function initializeAuras() {
     return;
  }
  function ResetAuras(){
-
+    killcommand.cooldown = 0;
+    pet.ferocious.timer = 0;
+    pet.frenzy.timer = 0;
+    
     auras.lust.timer = 0;
     auras.berserk.timer = 0;
     auras.bloodfury.timer = 0;

--- a/js/pet.js
+++ b/js/pet.js
@@ -404,10 +404,15 @@ function petCrit(){
         let frenzychance = talents.frenzy * 2000;
         pet.frenzy.timer = (roll <= frenzychance) ? 8 : pet.frenzy.timer; // proc check
         if(pet.frenzy.timer === 8) { 
-            if(combatlogRun && nextpetspell >= nextpetattack) {
-                combatlogarray[combatlogindex] = nextpetattack.toFixed(3) + " - Pet gains Frenzy";
-                combatlogindex++;
-            } else if (combatlogRun){
+            if(combatlogRun && petspell === 'kill command') {
+                combatlogarray[combatlogindex] = steptimeend.toFixed(3) + " - Pet gains Frenzy";
+                    combatlogindex++;
+            } 
+            else if(combatlogRun && nextpetspell >= nextpetattack) {
+                    combatlogarray[combatlogindex] = nextpetattack.toFixed(3) + " - Pet gains Frenzy";
+                    combatlogindex++;
+            } 
+            else if (combatlogRun){
                 combatlogarray[combatlogindex] = nextpetspell.toFixed(3) + " - Pet gains Frenzy";
                 combatlogindex++;
             }
@@ -416,10 +421,15 @@ function petCrit(){
     //ferocious insp
     if (talents.ferocious_insp > 1) {
         pet.ferocious.timer = 10;
-        if(combatlogRun && nextpetspell >= nextpetattack) {
+        if(combatlogRun && petspell === 'kill command') {
+            combatlogarray[combatlogindex] = steptimeend.toFixed(3) + " - Pet gains Ferocious Inspiration";
+                combatlogindex++;
+        } 
+        else if(combatlogRun && nextpetspell >= nextpetattack) {
             combatlogarray[combatlogindex] = nextpetattack.toFixed(3) + " - Pet gains Ferocious Inspiration";
             combatlogindex++;
-        } else if (combatlogRun){
+        } 
+        else if (combatlogRun){
             combatlogarray[combatlogindex] = nextpetspell.toFixed(3) + " - Pet gains Ferocious Inspiration";
             combatlogindex++;
         }

--- a/js/player.js
+++ b/js/player.js
@@ -976,9 +976,7 @@ function procattack(attack,result) {
    // blackened naaru sliver - roll to buff
    if (auras.naarusliver.enable && auras.naarusliver.cooldown === 0){
       roll = rng10k(); 
-      if(rangehit) {PPM = 1/60 * RANGED_WEAPONS[gear.range.id].speed * 100; }
-      if(meleehit) {PPM = BaseMeleeSpeed / 60 * 100; }
-      procchance = auras.naarusliver.ppm * PPM;
+      procchance = auras.naarusliver.procchance;
       auras.naarusliver.timer = (roll <= procchance * 100) ? auras.naarusliver.duration : 0;
       if(auras.naarusliver.timer === auras.naarusliver.duration) { 
          auras.naarusliver.cooldown = 45; 


### PR DESCRIPTION
- removed PPM from Naaru sliver because it has base 10% chance to proc regardless of wep
- fixed an issue with pet combat log for auras recording the wrong time for kill command crits
- fixed an issue where pet cds carried over from the previous iteration