### PR TITLE
Fix some minor things and begin stat weights

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -446,42 +446,57 @@ ul {
 
 }
 .select-1 {
-    left: 96px;
+  float: right;
+  right: 40px;
   }
 .select-2 {
-    left: 80px;
+  float: right;
+  right: 40px;
 
 }
 .select-3 {
   position: absolute;
   top: 160px; /*158px*/
-  left: 240px;
   height: 48px;
+  float: right;
+  right: 44px;
 
 }
 .select-4 {
-    left: 110px;
+  float: right;
+  right: 40px;
 }
 .select-5 {
   /* Reset */
-  left: 85px;
+  float: right;
+  right: 40px;
 }
 .select-6 {
-    left: 138px;
+  float: right;
+  right: 40px;
 }
 .select-7 {
     /* Reset */
-    left: 102px;
+    float: right;
+  right: 40px;
 
 }
 .select-8 {
   /* Reset */
-  left: 3px;
+  float: right;
+  right: 40px;
 
 }
 .select-9 {
   /* Reset */
   left: -7px;
+
+}
+
+.select-10 {
+  /* Reset */
+  float: right;
+  right: 40px;
 
 }
 .select-relative {

--- a/index.html
+++ b/index.html
@@ -379,15 +379,11 @@
                         <p class="u-align-right u-text u-text-custom-color-4 weight-name">0.42</p>
                       </div>
                       <div class="stat-item">
-                        <p class="u-align-left u-text stat-name">Stamina</p>
-                        <p class="u-align-right u-text u-text-custom-color-4 weight-name">0.42</p>
-                      </div>
-                      <div class="stat-item">
                         <p class="u-align-left u-text stat-name">Intellect</p>
                         <p class="u-align-right u-text u-text-custom-color-4 weight-name">0.42</p>
                       </div>
                       <div class="stat-item">
-                        <p class="u-align-left u-text stat-name">Spirit</p>
+                        <p class="u-align-left u-text stat-name">Mp5</p>
                         <p class="u-align-right u-text u-text-custom-color-4 weight-name">0.42</p>
                       </div>
                     </div>
@@ -428,10 +424,6 @@
                       </div>
                       <div class="stat-item">
                         <p class="u-align-left u-text stat-name">Expertise</p>
-                        <p class="u-align-right u-text u-text-custom-color-4 weight-name">0.42</p>
-                      </div>
-                      <div class="stat-item">
-                        <p class="u-align-left u-text stat-name">Mp5</p>
                         <p class="u-align-right u-text u-text-custom-color-4 weight-name">0.42</p>
                       </div>
                     </div>
@@ -922,6 +914,7 @@
 
     <script class="u-script" type="text/javascript" src="js/datastorage.js"></script>
     <script class="u-script" type="text/javascript" src="js/gearui.js"></script> 
+    <script class="u-script" type="text/javascript" src="js/importdata.js"></script> 
     <script class="u-script" type="text/javascript" src="js/ui.js"></script> 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script class="u-script" type="text/javascript" src="js/stats.js"></script> 

--- a/index.html
+++ b/index.html
@@ -488,7 +488,11 @@
         <option selected value="base">Base</option>
       </select></label></li>
         <img class="settings-image-4" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_unyeildingstamina.jpg" alt="">
-      <li><label class="container container-1">Leader of the Pack<input type="checkbox" id="lotp" onclick="lotpCheck()"><span class="checkmark"></span></label></li>
+      <li><label class="container container-2">Leader of the Pack<input type="checkbox" id="lotp" onclick="lotpCheck()"><span class="checkmark"></span>
+      <select onchange="lotpCheck()" class="select hover-grey select-10">
+        <option value="idol" id="lotpidol">Crit Idol</option>
+        <option selected value="none">None</option>
+      </select></label></li>
         <img class="settings-image-5" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_invisibilitytotem.jpg" alt="">
       <li><label class="container container-2">Grace of Air Totem<input type="checkbox" id="goa" onclick="totemCheck()"><span class="checkmark"></span></label></li>
         <img class="settings-image-6" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_earthbindtotem.jpg" alt="">

--- a/js/data/buffs.js
+++ b/js/data/buffs.js
@@ -127,5 +127,12 @@ const BUFFS = {
     stats: {
       Crit: 28
     }
+  },
+  39926: {
+    name: 'Improved Party Auras',
+    icon: 'inv-mount_raven_54',
+    stats: {
+      Crit: 20
+    }
   }
 };

--- a/js/data/gear.js
+++ b/js/data/gear.js
@@ -11357,7 +11357,7 @@ const SHOULDERS = {
         icon: "inv_shoulder_18",
         quality: "Rare"
     },
-    28589: {
+    30892: {
         name: "Beast-tamer's Shoulders",
         stats: {
             Agi: 39,
@@ -11365,9 +11365,13 @@ const SHOULDERS = {
             MAP: 78,
             RAP: 78
         },
+        special: {
+            pet_dmg_bonus: 1.03,
+            pet_crit_bonus: 2,
+        },
         Location: "Mount Hyjal",
         Phase: 3,
-        icon: "inv_shoulder_36",
+        icon: "inv_shoulder_59",
         quality: "Epic"
     },
     28755: {
@@ -11537,7 +11541,7 @@ const SHOULDERS = {
         icon: "inv_shoulder_18",
         quality: "Uncommon"
     },
-    30892: {
+    28589: {
         name: "Beastmaw Pauldrons",
         stats: {
             Agi: 24,
@@ -11549,7 +11553,7 @@ const SHOULDERS = {
         },
         Location: "Karazhan",
         Phase: 1,
-        icon: "inv_shoulder_59",
+        icon: "inv_shoulder_36",
         quality: "Epic"
     },
     30917: {

--- a/js/datastorage.js
+++ b/js/datastorage.js
@@ -236,6 +236,7 @@ function fetchData(){
     document.getElementById("wisdom").checked = (buffslist[2].id == 27143) ? true : false;
     document.getElementById("wisdommod").selected = (buffslist[2].talented) ? true : false;
     document.getElementById("lotp").checked = (buffslist[3] == 17007) ? true : false;
+    document.getElementById("lotpidol").selected = (buffslist[17] == 39926) ? true : false;
     document.getElementById("goa").checked = (buffslist[4].id == 25359) ? true : false;
     document.getElementById("soe").checked = (buffslist[5].id == 25528) ? true : false;
     document.getElementById("imptotem").selected = (buffslist[4].talented) ? true : false;

--- a/js/gearui.js
+++ b/js/gearui.js
@@ -533,8 +533,8 @@ function gearSlotsDisplay(){
     
     document.getElementById("shoulderslot").href = "https://tbc.wowhead.com/item="+ shoulderdata;
     document.getElementById("shoulderslot").innerHTML = SHOULDERS[gear.shoulder.id].name;
-    document.getElementById("shoulderench").href = (headench > 0) ? "https://tbc.wowhead.com/spell="+ shoulderench : "";
-    document.getElementById("shoulderench").innerHTML = (headench > 0) ? SHOULDER_ENCHANTS[gear.shoulder.enchant].name: "No Enchant";
+    document.getElementById("shoulderench").href = (shoulderench > 0) ? "https://tbc.wowhead.com/spell="+ shoulderench : "";
+    document.getElementById("shoulderench").innerHTML = (shoulderench > 0) ? SHOULDER_ENCHANTS[gear.shoulder.enchant].name: "No Enchant";
     
     // back
     textColorDisplay('back',BACKS);

--- a/js/importdata.js
+++ b/js/importdata.js
@@ -1,0 +1,302 @@
+var importeddata = {
+    "name": "P5 BiS current sims",
+    "phase": 5,
+    "links": {
+        "set": "https://seventyupgrades.com/set/vdKs4tRdGdoJBAgAjMEtJA"
+    },
+    "character": {
+        "name": "Sixxfury",
+        "level": 70,
+        "gameClass": "HUNTER",
+        "race": "ORC",
+        "faction": "HORDE"
+    },
+    "items": [
+        {
+            "name": "Coif of Alleria",
+            "id": 34333,
+            "enchant": {
+                "name": "Glyph of Ferocity",
+                "id": 3003,
+                "itemId": 29192,
+                "acquired": true
+            },
+            "gems": [
+                {
+                    "name": "Crimson Sun",
+                    "id": 33131
+                },
+                {
+                    "name": "Relentless Earthstorm Diamond",
+                    "id": 32409
+                }
+            ],
+            "slot": "HEAD"
+        },
+        {
+            "name": "Hard Khorium Choker",
+            "id": 34358,
+            "gems": [
+                {
+                    "name": "Stone of Blades",
+                    "id": 33143
+                }
+            ],
+            "slot": "NECK"
+        },
+        {
+            "name": "Gronnstalker's Spaulders",
+            "id": 31006,
+            "enchant": {
+                "name": "Might of the Scourge",
+                "id": 2717,
+                "itemId": 23548
+            },
+            "gems": [
+                {
+                    "name": "Wicked Pyrestone",
+                    "id": 32222
+                },
+                {
+                    "name": "Shifting Shadowsong Amethyst",
+                    "id": 32212
+                }
+            ],
+            "slot": "SHOULDERS"
+        },
+        {
+            "name": "Bladed Chaos Tunic",
+            "id": 34397,
+            "enchant": {
+                "name": "Enchant Chest - Exceptional Stats",
+                "id": 2661,
+                "spellId": 27960
+            },
+            "gems": [
+                {
+                    "name": "Shifting Shadowsong Amethyst",
+                    "id": 32212
+                },
+                {
+                    "name": "Wicked Pyrestone",
+                    "id": 32222
+                },
+                {
+                    "name": "Delicate Crimson Spinel",
+                    "id": 32194
+                }
+            ],
+            "slot": "CHEST"
+        },
+        {
+            "name": "Gronnstalker's Belt",
+            "id": 34549,
+            "gems": [
+                {
+                    "name": "Delicate Crimson Spinel",
+                    "id": 32194
+                }
+            ],
+            "slot": "WAIST"
+        },
+        {
+            "name": "Leggings of the Immortal Night",
+            "id": 34188,
+            "enchant": {
+                "name": "Nethercobra Leg Armor",
+                "id": 3012,
+                "itemId": 29535
+            },
+            "gems": [
+                {
+                    "name": "Delicate Crimson Spinel",
+                    "id": 32194
+                },
+                {
+                    "name": "Delicate Crimson Spinel",
+                    "id": 32194
+                },
+                {
+                    "name": "Delicate Crimson Spinel",
+                    "id": 32194
+                }
+            ],
+            "slot": "LEGS"
+        },
+        {
+            "name": "Gronnstalker's Boots",
+            "id": 34570,
+            "enchant": {
+                "name": "Enchant Boots - Dexterity",
+                "id": 2657,
+                "spellId": 27951
+            },
+            "gems": [
+                {
+                    "name": "Wicked Pyrestone",
+                    "id": 32222
+                }
+            ],
+            "slot": "FEET"
+        },
+        {
+            "name": "Gronnstalker's Bracers",
+            "id": 34443,
+            "enchant": {
+                "name": "Enchant Bracer - Assault",
+                "id": 1593,
+                "spellId": 34002
+            },
+            "gems": [
+                {
+                    "name": "Delicate Crimson Spinel",
+                    "id": 32194
+                }
+            ],
+            "slot": "WRISTS"
+        },
+        {
+            "name": "Thalassian Ranger Gauntlets",
+            "id": 34343,
+            "enchant": {
+                "name": "Enchant Gloves - Superior Agility",
+                "id": 2564,
+                "spellId": 25080
+            },
+            "gems": [
+                {
+                    "name": "Delicate Crimson Spinel",
+                    "id": 32194
+                },
+                {
+                    "name": "Glinting Pyrestone",
+                    "id": 32220
+                }
+            ],
+            "slot": "HANDS"
+        },
+        {
+            "name": "Hard Khorium Band",
+            "id": 34361,
+            "slot": "FINGER_1"
+        },
+        {
+            "name": "Band of Ruinous Delight",
+            "id": 34189,
+            "slot": "FINGER_2"
+        },
+        {
+            "name": "Blackened Naaru Sliver",
+            "id": 34427,
+            "slot": "TRINKET_1"
+        },
+        {
+            "name": "Dragonspine Trophy",
+            "id": 28830,
+            "slot": "TRINKET_2"
+        },
+        {
+            "name": "Cloak of Unforgivable Sin",
+            "id": 34241,
+            "enchant": {
+                "name": "Enchant Cloak - Greater Agility",
+                "id": 368,
+                "spellId": 34004
+            },
+            "gems": [
+                {
+                    "name": "Glinting Pyrestone",
+                    "id": 32220
+                }
+            ],
+            "slot": "BACK"
+        },
+        {
+            "name": "Shivering Felspine",
+            "id": 34183,
+            "enchant": {
+                "name": "Enchant 2H Weapon - Major Agility",
+                "id": 2670,
+                "spellId": 27977
+            },
+            "gems": [
+                {
+                    "name": "Wicked Pyrestone",
+                    "id": 32222
+                }
+            ],
+            "slot": "MAIN_HAND"
+        },
+        {
+            "name": "Thori'dal, the Stars' Fury",
+            "id": 34334,
+            "enchant": {
+                "name": "Stabilized Eternium Scope",
+                "id": 2724,
+                "itemId": 23766
+            },
+            "slot": "RANGED"
+        },
+        {
+            "name": "Tabard of the Protector",
+            "id": 28788,
+            "acquired": true,
+            "slot": "TABARD"
+        }
+    ],
+    "points": [
+        {
+            "name": "Sixx Weights",
+            "stats": {
+                "agility": 2.25,
+                "attackPower": 1,
+                "rangedAttackPower": 1,
+                "hitRating": 0.9,
+                "critRating": 1.9,
+                "hasteRating": 1.91,
+                "armorPen": 0.34,
+                "rangedHitRating": 1.8,
+                "rangedCritRating": 1.9,
+                "metaSockets": 77.2,
+                "redSockets": 17.9,
+                "blueSockets": 17.9,
+                "yellowSockets": 17.9,
+                "rangedDps": 4,
+                "rangedSpeed": 50
+            }
+        }
+    ],
+    "stats": {
+        "agility": 752,
+        "armor": 6802,
+        "armorPen": 1739,
+        "attackPower": 2365,
+        "crit": 29.18,
+        "critRating": 263,
+        "defense": 350,
+        "dodge": 24.63,
+        "haste": 12.43,
+        "hasteRating": 196,
+        "health": 8858,
+        "hit": 6.09,
+        "hitRating": 96,
+        "intellect": 203,
+        "mainHandSpeed": 3.5,
+        "mana": 6148,
+        "parry": 5,
+        "rangedAttackPower": 2302,
+        "rangedCrit": 30.45,
+        "rangedCritRating": 291,
+        "rangedHit": 6.09,
+        "rangedHitRating": 96,
+        "rangedSpeed": 2.7,
+        "spellCrit": 6.14,
+        "spirit": 92,
+        "stamina": 547,
+        "strength": 73
+    },
+    "exportOptions": {
+        "buffs": false,
+        "talents": false
+    }
+}

--- a/js/pet.js
+++ b/js/pet.js
@@ -84,7 +84,13 @@ var selectedPet = 0;
 function petStatsCalc(){
 
     let racialmod = (selectedRace === 3) ? 1.05 : 1; // 5% pet dmg if orc
-    pet.dmgmod = PetHappiness * talents.unleash_fury * PETS[selectedPet].dmgmod * racialmod;
+    let beasttamers_crit = 0;
+    let beasttamers_dmg = 1;
+    if (gear.shoulder.id === 30892) {
+        beasttamers_dmg = 1.02;
+        beasttamers_crit = 2;
+    };
+    pet.dmgmod = PetHappiness * talents.unleash_fury * PETS[selectedPet].dmgmod * racialmod * beasttamers_dmg;
 
     pet.str = Math.floor((PetBaseStr + (selectedbuffs.stats.Str || 0) + (petconsumestats.Str || 0)) * selectedbuffs.special.kingsMod);
     pet.agi = Math.floor((PetBaseAgi + (selectedbuffs.stats.Agi || 0) + (petconsumestats.Agi || 0)) * selectedbuffs.special.kingsMod);
@@ -93,7 +99,7 @@ function petStatsCalc(){
     let petAPfromplayer = BaseRAP * 0.22;
     pet.ap = (pet.str - 10) * 2 + (selectedbuffs.stats.MAP || 0) + petAPfromplayer;
     //crit
-    pet.crit = PetBaseCrit + pet.agi / 33 + talents.ferocity + (selectedbuffs.stats.CritChance || 0) + CritPenalty; // need to add special gear items w/ pet crit
+    pet.crit = PetBaseCrit + pet.agi / 33 + talents.ferocity + (selectedbuffs.stats.CritChance || 0) + beasttamers_crit + CritPenalty; // need to add special gear items w/ pet crit
     //hit
     pet.hit = talents.animal_handler ; // need to add heroic presence
     let penalty = (RangeHitChance >= 1) ? HitPenalty : 0; // include penalty here? assumes lvl 73 target
@@ -108,7 +114,7 @@ function petStatsCalc(){
         case 'claw': spellindex = 2; break;
         case 'gore': spellindex = 3; break;
         case 'lightning breath': spellindex = 4; break;
-        case 'thunerstomp': spellindex = 5; break;
+        case 'thunderstomp': spellindex = 5; break;
         case 'fire breath': spellindex = 6; break;
         case 'poison spit': spellindex = 7; break;
         case 'scorpid poison': spellindex = 8; break;

--- a/js/pet.js
+++ b/js/pet.js
@@ -233,7 +233,7 @@ function petRollSpell(specialcrit){
     if (roll < tmp) return RESULT.MISS;
     tmp += PetBaseDodge * 100;
     if (roll < tmp) return RESULT.DODGE;
-    tmp += (100 - pet.combatmiss) * crit; // pseudo 2 roll
+    tmp += (100 - pet.combatmiss - PetBaseDodge) * crit; // pseudo 2 roll
     if (roll < tmp) return RESULT.CRIT;
     return RESULT.HIT;
     
@@ -247,7 +247,7 @@ function petRollMagicSpell(){
     if (roll < tmp) return RESULT.MISS;
     tmp += 14.5 * 100; // partial resist rate approx. 14.5% based on log data at 0 resistance
     if (roll < tmp) return RESULT.PARTIAL;
-    tmp += (100 - hit) * pet.combatspellcrit; // pseudo 2 roll
+    tmp += (100 - hit - 14.5) * pet.combatspellcrit; // pseudo 2 roll
     if (roll < tmp) return RESULT.CRIT;
     return RESULT.HIT;
 }
@@ -284,7 +284,7 @@ function petAttack(){
     petsteptime = nextpetattack;
     nextpetattack += pet.combatspeed;
     petautocount++;
-    petdmg.attackdmg += dmg;
+    petdmg.attackdmg += done;
     if(combatlogRun) {
         combatlogarray[combatlogindex] = petsteptime.toFixed(3) + " - Pet Auto " + RESULTARRAY[result] + " for " + done;
         combatlogindex++;
@@ -315,7 +315,6 @@ function petSpell(petspell){
         }
         petkccount++;
         spelltype = "phys";
-        petdmg.kcdmg += dmg;
         
     } // primary spell use determined by which pet selected
     else if(petspell === 'primary') {
@@ -358,10 +357,14 @@ function petSpell(petspell){
         petsteptime = nextpetspell; // since pet steps don't change time (all instants) set time to current time
         nextpetspell = nextpetspell + 1.5; // set next available spell time by 1.5
         petprimarycount++;
-        petdmg.primarydmg += dmg;
     }
     let done = petdealdamage(dmg,result,spelltype); // need special case for magic spells pet or player
     petdmgdone += done;
+    if (petspell === 'kill command'){
+        petdmg.kcdmg += done;
+    } else if (petspell === 'primary'){
+        petdmg.primarydmg += done;
+    }
     petUpdateHaste();
     
     if(combatlogRun && petspell === 'kill command') {

--- a/js/player.js
+++ b/js/player.js
@@ -88,6 +88,21 @@ var mainhand_wep = {};
 var consumestats = {};
 var target = {};
 var currentgear = {auras:{0:{}}, stats:{},special:{}};
+var custom = {
+   str: 0,
+   agi: 0,
+   int: 0,
+   RAP: 0,
+   rangehit: 0,
+   rangecrit: 0,
+   haste: 0,
+   arp: 0,
+   MAP: 0,
+   meleehit: 0,
+   meleecrit: 0,
+   expertise: 0,
+   mp5: 0
+};
 
 const GearStats = {Str:0, Agi:0, Stam:0, Int:0, Spi:0, RAP:0, MAP:0, Crit:0, Hit:0, MP5:0, Resil:0, ArP:0, Haste:0,Exp:0,dmgbonus:0, rangedmgbonus:0}; 
 const BuffStats = {Str:0, Agi:0, Stam:0, Int:0, Spi:0, RAP:0, MAP:0, Crit:0, CritChance:0, Hit:0, HitChance:0, MP5:0, Resil:0, ArP:0, Haste:0};
@@ -238,7 +253,7 @@ function calcBaseStats() {
   } else if(target.type === 'Humanoid') {
       slaying = talents.humanoid_slaying;
   }
-  console.log(racialmod);
+
   dmgmod = (1 + talents.focused_fire / 100) * selectedbuffs.special.impSancAura * slaying * racialmod;
   rangedmgmod = dmgmod * (talents.ranged_weap_spec);
 
@@ -251,32 +266,32 @@ function calcBaseStats() {
   mapmod = talents.surv_instincts * 1;
   rapmod = talents.master_marksman * talents.surv_instincts * 1;
   // Main Stats
-  Str  = Math.floor((GearStats.Str + BuffStats.Str + EnchantStats.Str + races[selectedRace].str) * strmod);
-  Agi  = Math.floor((GearStats.Agi + BuffStats.Agi + EnchantStats.Agi + races[selectedRace].agi) * agimod);
+  Str  = Math.floor((GearStats.Str + BuffStats.Str + EnchantStats.Str + races[selectedRace].str + custom.str) * strmod);
+  Agi  = Math.floor((GearStats.Agi + BuffStats.Agi + EnchantStats.Agi + races[selectedRace].agi + custom.agi) * agimod);
   Stam = Math.floor((GearStats.Stam + BuffStats.Stam + EnchantStats.Stam + races[selectedRace].sta) * stammod);
-  Int  = Math.floor((GearStats.Int + BuffStats.Int + EnchantStats.Int + races[selectedRace].int) * intmod);
+  Int  = Math.floor((GearStats.Int + BuffStats.Int + EnchantStats.Int + races[selectedRace].int + custom.int) * intmod);
   Spi  = Math.floor((GearStats.Spi + BuffStats.Spi + EnchantStats.Spi + races[selectedRace].spi) * spimod);
 
   // Attack Power
   let tsa_ap = (talents.trueshot_aura > 0) ? 125 : 0;
-  BaseMAP = (GearStats.MAP + BuffStats.MAP + EnchantStats.MAP + Agi + Str + races[selectedRace].mAP + tsa_ap) * mapmod;
+  BaseMAP = (GearStats.MAP + BuffStats.MAP + EnchantStats.MAP + Agi + Str + races[selectedRace].mAP + tsa_ap + custom.MAP) * mapmod;
   // flat 155 added for Aspect of the Hawk - need to change later
-  BaseRAP = (155 + GearStats.RAP + BuffStats.RAP + EnchantStats.RAP + Agi + races[selectedRace].rAP + Int * talents.careful_aim + tsa_ap) * rapmod;
-   let critsuppression = CritPenalty + CritAuraPenalty;
+  BaseRAP = (155 + GearStats.RAP + BuffStats.RAP + EnchantStats.RAP + Agi + races[selectedRace].rAP + Int * talents.careful_aim + tsa_ap + custom.RAP) * rapmod;
+  
   // Crit rating and crit chance
    let critrating = GearStats.Crit + BuffStats.Crit + EnchantStats.Crit;
-  MeleeCritRating = critrating;
-  RangeCritRating = critrating + (currentgear.stats.RangeCrit || 0);
+  MeleeCritRating = critrating + custom.meleecrit;
+  RangeCritRating = critrating + (currentgear.stats.RangeCrit || 0) + custom.rangecrit;
    let crit = BaseCritChance + Agi / AgiToCrit + BuffStats.CritChance + talents.killer_instinct;
-  MeleeCritChance = crit + MeleeCritRating / CritRatingRatio + critsuppression;
-  RangeCritChance = crit + RangeCritRating / CritRatingRatio + talents.lethal_shots + races[selectedRace].critchance + critsuppression;
+  MeleeCritChance = crit + MeleeCritRating / CritRatingRatio;
+  RangeCritChance = crit + RangeCritRating / CritRatingRatio + talents.lethal_shots + races[selectedRace].critchance;
   
   MeleeCritDamage = 2 * (currentgear.special.relentless_metagem_crit_dmg_inc * 1);
   RangeCritDamage = 1 + (talents.mortal_shots) * (2 * slaying * currentgear.special.relentless_metagem_crit_dmg_inc - 1);
   // Hit rating and hit chance - split between ranged and melee because of hit scope and crit scope and racial
    let hitrating = GearStats.Hit + BuffStats.Hit + EnchantStats.Hit;
-  MeleeHitRating = hitrating;
-  RangeHitRating = hitrating + EnchantStats.RangeHit;
+  MeleeHitRating = hitrating + custom.meleehit;
+  RangeHitRating = hitrating + EnchantStats.RangeHit + custom.rangehit;
    let hit = BaseHitChance + talents.surefooted + BuffStats.HitChance;
   MeleeHitChance = hit + MeleeHitRating / HitRatingRatio; // need dual wield condition
   RangeHitChance = hit + RangeHitRating / HitRatingRatio;
@@ -285,11 +300,11 @@ function calcBaseStats() {
   RangeMissChance = Math.max(8 - RangeHitChance - penalty,0);
 
   // Expertise and Dodge - every 3.9 rating is 1 expertise, 1 expertise = 0.25% reduction rounded down to nearest integer
-  Expertise = Math.floor(GearStats.Exp / ExpertiseRatio + races[selectedRace].expertise);
+  Expertise = Math.floor(GearStats.Exp / ExpertiseRatio + races[selectedRace].expertise + custom.expertise);
   DodgeChance = 6.5 - Expertise * 0.25;
 
-  ArmorPen = GearStats.ArP;
-  ManaPer5 = Math.floor(BuffStats.MP5 + GearStats.MP5 + EnchantStats.MP5);
+  ArmorPen = GearStats.ArP + custom.arp;
+  ManaPer5 = Math.floor(BuffStats.MP5 + GearStats.MP5 + EnchantStats.MP5 + custom.mp5);
   // formula for spirit regen -> (5 * sqrt(intellect) * spirit * 0.009327) for hunters
   fiveSecRulemp5 = Math.floor(5 * (Math.sqrt(Int) * Spi * BaseRegen));
 
@@ -298,7 +313,7 @@ function calcBaseStats() {
   // initialize current Mana to Max mana
   currentMana = Mana;
   
-  HasteRating = BuffStats.Haste + GearStats.Haste + EnchantStats.Haste;
+  HasteRating = BuffStats.Haste + GearStats.Haste + EnchantStats.Haste + custom.haste;
   
   BaseRangeSpeed = RANGED_WEAPONS[gear.range.id].speed / QuiverSpeed / talents.serp_swift;
   BaseMeleeSpeed = MELEE_WEAPONS[gear.mainhand.id].speed;
@@ -585,7 +600,8 @@ function updateDamageMod() {
 
 // handling for crit changes
 function updateCritChance() {
-   let combatCritChance = RangeCritChance;
+   let critsuppression = CritPenalty + CritAuraPenalty;
+   let combatCritChance = RangeCritChance + critsuppression;
    if(auras.mastertact.timer > 0) { combatCritChance += talents.master_tac; } // master tactician
    
    // from agi changes

--- a/js/statCalculator.js
+++ b/js/statCalculator.js
@@ -3,14 +3,14 @@
   AUXILIAR FUNCTIONS
   --------------------------------------------------------------------------------- */
 
-/* Auxiliar function to sum two stat objects. Accepts a statModifier
+/** Auxiliar function to sum two stat objects. Accepts a statModifier
    function, to apply a modification to each stat */
 function sumStats(src, dst, statModifier = st => st) {
   Object.entries(src).forEach(([stat, amount]) => dst[stat] = (dst[stat] || 0) + statModifier(amount))
 }
 
 const SPECIAL_ADD = ['incWeapDmg']
-/* Auxiliar function to add two special objects. Will overwrite dst values if one prop appears in both objects,
+/** Auxiliar function to add two special objects. Will overwrite dst values if one prop appears in both objects,
    unless they are in the SPECIAL_ADD list */
 function addSpecial(src, dst) {
   Object.entries(src).forEach(([k,v])=> {
@@ -19,7 +19,7 @@ function addSpecial(src, dst) {
   })
 }
 
-// Auxiliar function to add two aura objects. Will throw error if an aura appears in both objects.
+/** Auxiliar function to add two aura objects. Will throw error if an aura appears in both objects. */
 function addAuras(src, dst) {
   Object.entries(src).forEach(([k,v]) => {
     if (dst[k]) throw new Error(`An aura with id ${k} already exists!`)
@@ -27,7 +27,7 @@ function addAuras(src, dst) {
   })
 }
 
-// Auxiliar function that adds special, auras and stats of two objects
+/** Auxiliar function that adds special, auras and stats of two objects */
 function mergeResults(src, dst) {
   if (src.stats) sumStats(src.stats, dst.stats)
   if (src.special) addSpecial(src.special, dst.special)
@@ -38,7 +38,7 @@ function mergeResults(src, dst) {
   BUFFS
   --------------------------------------------------------------------------------- */
 
-/* Auxiliar function to generate a function that modifies the value of a buff,
+/** Auxiliar function to generate a function that modifies the value of a buff,
    based on a flat improvement and a ratio */
 function buildStatModifier(props, buff) {
   let bonus = 0
@@ -53,7 +53,7 @@ function buildStatModifier(props, buff) {
   return st => (st + bonus) * ratio
 }
 
-/* Given an array of buff objects, it will return an object with stats and special bonuses,
+/** Given an array of buff objects, it will return an object with stats and special bonuses,
    applying different modifiers to each buff based on the data provided */
 function getStatsFromBuffs(buffs) {
   const usedBuffs = {}
@@ -80,7 +80,7 @@ function getStatsFromBuffs(buffs) {
   CONSUMABLES
   --------------------------------------------------------------------------------- */
 
-/* Given an object of consumables and a consumable map, it will use the map to
+/** Given an object of consumables and a consumable map, it will use the map to
    calculate stats and verify proper consumables are used */
 function getStatsFromConsumes(consumables, source) {
   return Object.entries(consumables).reduce((stats, [type, id]) => {
@@ -92,7 +92,7 @@ function getStatsFromConsumes(consumables, source) {
   }, {})
 }
 
-// Given an object of consumables, returns stat increase for players
+/** Given an object of consumables, returns stat increase for players */
 function getPlayerStatsFromConsumes(consumables) {
   if (consumables.flask && (consumables.battle_elixir || consumables.guardian_elixir))
     throw Error('Detected flask AND elixir. You must use one OR the other.')
@@ -100,7 +100,7 @@ function getPlayerStatsFromConsumes(consumables) {
   return getStatsFromConsumes(consumables, PLAYER_CONSUMABLES)
 }
 
-// Given an object of consumables, returns stat increase for pets
+/** Given an object of consumables, returns stat increase for pets */
 function getPetStatsFromConsumes(consumables) {
   return getStatsFromConsumes(consumables, PET_CONSUMABLES)
 }
@@ -109,7 +109,7 @@ function getPetStatsFromConsumes(consumables) {
   GEAR
   --------------------------------------------------------------------------------- */
 
-/* Given the used meta and the amount of gems used per color, calculates bonuses provided by metagem,
+/** Given the used meta and the amount of gems used per color, calculates bonuses provided by metagem,
    It loops over all the metagems so it can provide default multipliers */
 function getMetagemBonuses(usedMeta, gemsUsed) {
   const noGems = { yellow: 0, red: 0, blue: 0}
@@ -128,7 +128,7 @@ function getMetagemBonuses(usedMeta, gemsUsed) {
   return result
 }
 
-// Given the gear object, calculates stats, auras and special values obtained from gems, socket bonuses and meta gem.
+/** Given the gear object, calculates stats, auras and special values obtained from gems, socket bonuses and meta gem. */
 function getStatsFromGems(gear) {
   let usedMeta
   const gemCount = { red: 0, yellow: 0, blue: 0 }
@@ -179,7 +179,7 @@ function getStatsFromGems(gear) {
   return result
 }
 
-// Given the gear object, calculates stats, auras and special values obtained from enchants
+/** Given the gear object, calculates stats, auras and special values obtained from enchants */
 function getStatsFromEnchants(gear) {
   return Object.entries(gear).reduce((result, [type, gearData]) => {
     const enchantId = gearData.enchant
@@ -225,7 +225,7 @@ function getSetBonuses(setPieces) {
 const ALLOWED_IN_MAINHAND = ['Two', 'Main', 'One']
 const ALLOWED_IN_OFFHAND = ['Off', 'One']
 
-// Given the gear object, calculates stats, auras and special values obtained from gear pieces
+/** Given the gear object, calculates stats, auras and special values obtained from gear pieces */
 function getStatsFromGearPieces(gear) {
   const setPieces = {}
 
@@ -262,7 +262,7 @@ function getStatsFromGearPieces(gear) {
   return result
 }
 
-// Given the gear object, calculates stats, auras and specials obtained from gear pieces, enchants and gems
+/** Given the gear object, calculates stats, auras and specials obtained from gear pieces, enchants and gems */
 function getStatsFromGear(gear) {
   const result = getStatsFromGearPieces(gear)
   mergeResults(getStatsFromGems(gear), result)

--- a/js/stats.js
+++ b/js/stats.js
@@ -138,3 +138,176 @@ var histogram = new Chart(ctx, {
       }
   }
 });
+
+function damageResults(){
+  simresults = {
+      steady: {},
+      auto: {},
+      multi: {},
+      arcane: {},
+      attack: {},
+      kc: {},
+      primary: {}
+  };
+  // steady
+  simresults.steady.casts = (steadycount / iterations);
+  simresults.steady.miss = (spellresult.steadyshot.Miss / steadycount) * 100;
+  simresults.steady.crit = (spellresult.steadyshot.Crit / steadycount) * 100;
+  simresults.steady.hit = (spellresult.steadyshot.Hit / steadycount) * 100;
+  simresults.steady.avg = (steadydmg / steadycount);
+  simresults.steady.dps = (steadydmg / sumduration);
+  // auto
+  simresults.auto.casts = (autocount / iterations);
+  simresults.auto.miss = (spellresult.autoshot.Miss / autocount) * 100;
+  simresults.auto.crit = (spellresult.autoshot.Crit / autocount) * 100;
+  simresults.auto.hit = (spellresult.autoshot.Hit / autocount) * 100;
+  simresults.auto.avg = (autodmg / autocount);
+  simresults.auto.dps = (autodmg / sumduration);
+  // multi
+  if(SPELLS.multishot.enable){
+      simresults.multi.casts = (multicount / iterations);
+      simresults.multi.miss = (spellresult.multishot.Miss / multicount) * 100;
+      simresults.multi.crit = (spellresult.multishot.Crit / multicount) * 100;
+      simresults.multi.hit = (spellresult.multishot.Hit / multicount) * 100;
+      simresults.multi.avg = (multidmg / multicount);
+      simresults.multi.dps = (multidmg / sumduration);
+  }
+  // arcane
+  if(SPELLS.arcaneshot.enable){
+      simresults.arcane.casts = (arcanecount / iterations);
+      simresults.arcane.miss = (spellresult.arcaneshot.Miss / arcanecount) * 100;
+      simresults.arcane.crit = (spellresult.arcaneshot.Crit / arcanecount) * 100;
+      simresults.arcane.hit = (spellresult.arcaneshot.Hit / arcanecount) * 100;
+      simresults.arcane.avg = (arcanedmg / arcanecount);
+      simresults.arcane.dps = (arcanedmg / sumduration);
+  }
+  // pet auto
+  simresults.attack.casts = (petautocount / iterations);
+  simresults.attack.miss = (spellresult.petattack.Miss / petautocount) * 100;
+  simresults.attack.crit = (spellresult.petattack.Crit / petautocount) * 100;
+  simresults.attack.hit = (spellresult.petattack.Hit / petautocount) * 100;
+  simresults.attack.glance = (spellresult.petattack.Glance / petautocount) * 100;
+  simresults.attack.dodge = (spellresult.petattack.Dodge / petautocount) * 100;
+  simresults.attack.avg = (petdmg.attackdmg / petautocount);
+  simresults.attack.dps = (petdmg.attackdmg / sumduration);
+  // pet kill command
+  simresults.kc.casts = (petkccount / iterations);
+  simresults.kc.miss = (spellresult.killcommand.Miss / petkccount) * 100;
+  simresults.kc.crit = (spellresult.killcommand.Crit / petkccount) * 100;
+  simresults.kc.hit = (spellresult.killcommand.Hit / petkccount) * 100;
+  simresults.kc.dodge = (spellresult.killcommand.Dodge / petkccount) * 100;
+  simresults.kc.avg = (petdmg.kcdmg / petkccount);
+  simresults.kc.dps = (petdmg.kcdmg / sumduration);
+  // pet primary
+  simresults.primary.casts = (petprimarycount / iterations);
+  simresults.primary.miss = (spellresult.primary.Miss / petprimarycount) * 100;
+  simresults.primary.crit = (spellresult.primary.Crit / petprimarycount) * 100;
+  simresults.primary.hit = (spellresult.primary.Hit / petprimarycount) * 100;
+  simresults.primary.dodge = (spellresult.primary.Dodge / petprimarycount) * 100;
+  simresults.primary.partial = (spellresult.primary.Partial / petprimarycount) * 100;
+  simresults.primary.avg = (petdmg.primarydmg / petprimarycount);
+  simresults.primary.dps = (petdmg.primarydmg / sumduration);
+  
+  let newsimresults = Object.keys(simresults).map(key => ({action: key, results: simresults[key]}));
+  let sortedsimresults = newsimresults.sort(compare);
+  buildTable(sortedsimresults);
+
+  console.log("pet dmg => "+sumpetdmg / iterations);
+  console.log("total damage: " + sumdmg/iterations);
+  console.log("duration: " + (Math.round(sumduration/iterations * 100) / 100));
+}
+var actions = {
+auto: "Auto Shot",
+arcane: "Arcane Shot",
+steady: "Steady Shot",
+  multi: "Multi Shot",
+  attack: "Attack (Pet)",
+  kc: "Kill Command (Pet)",
+  primary: "Primary (Pet)",
+};
+function buildTable(results){
+
+  let act = '';
+  let tbody = document.getElementById('tbody');
+  tbody.innerHTML = '';
+  for (var i = 0; i < results.length; i++) {
+    let tr = "<tr>";
+    if (results[i].results.dps > 0) {
+      act = results[i].action; 
+      tr += "<td style='text-align:right'>" + actions[act] + "</td>" + 
+      "<td style='text-align:right'>" + (results[i].results.dps || 0).toFixed(2) + "</td>" + 
+      "<td style='text-align:right'>" + (results[i].results.casts || 0).toFixed(2) + "</td>" +
+      "<td style='text-align:right'>" + (results[i].results.avg || 0).toFixed(2) + "</td>" +
+      "<td style='text-align:right'>" + (results[i].results.hit || 0).toFixed(2) + "</td>" +
+      "<td style='text-align:right'>" + (results[i].results.crit || 0).toFixed(2) + "</td>" +
+      "<td style='text-align:right'>" + (results[i].results.miss || 0).toFixed(2) + "</td>" +
+      "<td style='text-align:right'>" + (results[i].results.dodge || 0).toFixed(2) + "</td>" +
+      "<td style='text-align:right'>" + (results[i].results.glance || 0).toFixed(2) + "</td>" +
+      "<td style='text-align:right'>" + (results[i].results.partial || 0).toFixed(2) + "</td>" +
+      "</tr>";
+      tbody.innerHTML += tr;
+    }
+  }
+}
+
+function compare(a, b) {
+  // Use toUpperCase() to ignore character casing
+  const dpsA = a.results.dps;
+  const dpsB = b.results.dps;
+
+  let comparison = 0;
+  if (dpsA > dpsB) {
+    comparison = -1;
+  } else if (dpsA < dpsB) {
+    comparison = 1;
+  }
+  return comparison;
+}
+
+/** Resets counts of spells used for stats */
+function resultCountInitialize() {
+  // player
+  for (spellname in spellresult){
+      spellresult[spellname].Hit = 0;
+      spellresult[spellname].Crit = 0;
+      spellresult[spellname].Miss = 0;
+      
+      if (spellname === 'primary') {
+          spellresult[spellname].Partial = 0;
+      }
+      if (spellname === 'primary' || 'petattack' || 'killcommand') {
+          spellresult[spellname].Dodge = 0;
+      }
+      if (spellname === 'petattack') {
+          spellresult[spellname].Glance = 0;
+      }
+
+  }
+  return;
+}
+
+function spellResultSum(result, spellname) {
+
+  if (result === RESULT.HIT) {
+      spellresult[spellname].Hit++;
+  }
+  else if (result === RESULT.GLANCE) {
+      spellresult[spellname].Glance++;
+  }
+  else if (result === RESULT.CRIT) {
+      spellresult[spellname].Crit++;
+  }
+  else if (result === RESULT.MISS) {
+      spellresult[spellname].Miss++;
+  }
+  else if (result === RESULT.DODGE) {
+      spellresult[spellname].Dodge++;
+  }
+  else if (result === RESULT.PARTIAL) {
+      spellresult[spellname].Partial++;
+  }
+  //console.log(result);
+  //console.log(spellname);
+  //console.log(spellresult);
+  return;
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -53,6 +53,22 @@ function displayDPSResults(){
     document.getElementById("dpserr").innerHTML = "DPS ​± " + err.toFixed(errrounding);
     document.getElementById("executetime").innerHTML = Math.round(executecodetime * 10000) / 10000 + " s";
 }
+
+function displayStatWeights(){
+    document.getElementsByClassName('weight-name')[0].innerHTML = statweights.str.toFixed(2);
+    document.getElementsByClassName('weight-name')[1].innerHTML = statweights.agi.toFixed(2);
+    document.getElementsByClassName('weight-name')[2].innerHTML = statweights.int.toFixed(2);
+    document.getElementsByClassName('weight-name')[3].innerHTML = statweights.mp5.toFixed(2);
+    document.getElementsByClassName('weight-name')[4].innerHTML = statweights.RAP.toFixed(2);
+    document.getElementsByClassName('weight-name')[5].innerHTML = statweights.rangehit.toFixed(2);
+    document.getElementsByClassName('weight-name')[6].innerHTML = statweights.rangecrit.toFixed(2);
+    document.getElementsByClassName('weight-name')[7].innerHTML = statweights.haste.toFixed(2);
+    document.getElementsByClassName('weight-name')[8].innerHTML = statweights.arp.toFixed(2);
+    document.getElementsByClassName('weight-name')[9].innerHTML = statweights.MAP.toFixed(2);
+    document.getElementsByClassName('weight-name')[10].innerHTML = statweights.meleehit.toFixed(2);
+    document.getElementsByClassName('weight-name')[11].innerHTML = statweights.meleecrit.toFixed(2);
+    document.getElementsByClassName('weight-name')[12].innerHTML = statweights.expertise.toFixed(2);
+}
 // initialize stats display
 displayStats();
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -16,7 +16,8 @@ var buffslist = [
     { id: 0, talented: false }, // BS
     0, // tsa
     0, // braided eternium
-    0 // imp sanctity
+    0, // imp sanctity
+    0  // feral crit idol
 ];
 var filteredbuffs = [];
 var playerconsumes = {};
@@ -298,6 +299,11 @@ function wisdomCheck() {
 function lotpCheck() {
     let isChecked = document.getElementById("lotp").checked; 
     buffslist[3] = isChecked ? 17007 : 0;
+    let isImproved = document.getElementById("lotpidol").selected;
+    if (isChecked && isImproved) {
+        buffslist[17] = 39926;
+    } 
+    else { buffslist[17] = 0; }
     selectedOptionsResults();
 
 }


### PR DESCRIPTION
- Added lotp idol crit selection
- fixed an issue with beast tamer shoulders using the wrong id and image
- fixed beast tamers shoulders specials
- fixed error with shoulder enchant not being selected
- fixed some 2 roll calcs for pets to include dodge and partial resists
- fixed pet damage totals for stats display
- added custom stats for stat weights calculations
- adjusted the loop and added stat weights calcs for testing
- added imported json example for testing
- moved most stats stuff to a separate file
- moved crit suppression to be in-combat so that the displayed crit is tooltip crit
- removed a couple of stats from the weights (stam, spi)