### PR TITLE
add import functionality for 70U links, cleanup of several areas

### DIFF
--- a/css/settings.css
+++ b/css/settings.css
@@ -254,7 +254,31 @@ ul {
   width: 600px;
   height: 300px;
 }
+.modal-import {
+  display: none; 
+  position: fixed; 
+  z-index: 1; 
+  padding-top: 100px; 
+  top: 0;
+  width: 100%; 
+  height: 100%; 
+  overflow-y: auto; 
+  background-color: rgb(0,0,0); 
+  background-color: rgba(0,0,0,0.2); 
 
+}
+/* import Modal Content */
+.modal-import-content {
+  position:absolute;
+  left: 35%;
+  background-color: #1e1e22;
+  top: 40%;
+  margin: auto;
+  padding: 20px;
+  border: 4px solid #2e2e33;
+  width: 600px;
+  height: 300px;
+}
 /* The Close Button */
 .close {
   color: #aaaaaa;

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
                       </h4>
                     </div>
                   </div>
-                  <a href="javascript:;" class="u-border-2 u-border-black u-border-hover-black u-btn u-btn-round u-button-style u-grey-70 u-hover-white u-radius-5 u-btn-4">Import<span style="font-size: 1rem;"></span>
+                  <a href="javascript:;" id="importbtn" class="u-border-2 u-border-black u-border-hover-black u-btn u-btn-round u-button-style u-grey-70 u-hover-white u-radius-5 u-btn-4">Import<span style="font-size: 1rem;"></span>
                   </a>
                   <h4 class="u-align-center u-text u-text-custom-color-3 u-text-24">Hunter<br>
                   </h4>
@@ -912,9 +912,25 @@
   </div>
 </div>
 
+<div id="importmodal" class="modal-import">
+  <div class="modal-import-content">
+    <span class="close">&times;</span>
+    <div>
+      <label for="import" class="header-1">Import Data:</label>
+
+      <textarea id="importdata" name="import" rows="4" cols="50"></textarea>
+      <br>
+      <button onclick="submitImportData()">Submit!</button>
+
+      <p id="confirmimport" class="label-2"></p>
+    </div>
+  </div>
+</div>
+
     <script class="u-script" type="text/javascript" src="js/datastorage.js"></script>
     <script class="u-script" type="text/javascript" src="js/gearui.js"></script> 
     <script class="u-script" type="text/javascript" src="js/importdata.js"></script> 
+    <script class="u-script" type="text/javascript" src="js/importer.js"></script>
     <script class="u-script" type="text/javascript" src="js/ui.js"></script> 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script class="u-script" type="text/javascript" src="js/stats.js"></script> 

--- a/js/auras.js
+++ b/js/auras.js
@@ -206,7 +206,7 @@ function initializeAuras() {
     auras.bloodfury.cooldown = auras.bloodfury.offset;
     auras.abacus.cooldown = 0;
     auras.drums.cooldown = auras.drums.offset;
-    auras.potion.cooldown = auras.potion.offset;
+    auras.potion.cooldown = (auras.potion.primary) ? auras.potion.offset : 0;
     auras.rune.cooldown = auras.rune.offset;
     auras.rapid.cooldown = auras.rapid.offset;
     auras.swarmguard.cooldown = 0;
@@ -648,8 +648,7 @@ function onUseSpellCheck(){
             combatlogindex++;
         }
     }
-    if((auras.potion.primary || auras.potion.secondary) && auras.potion.cooldown === 0) {
-        potionHandling();
+    if((auras.potion.primary || auras.potion.secondary) && auras.potion.cooldown === 0 && potionHandling()) {
         if(combatlogRun) {
             combatlogarray[combatlogindex] = steptimeend.toFixed(3) + " - Player used " + auras.potion.used + " Potion";
             combatlogindex++;

--- a/js/data/enchants.js
+++ b/js/data/enchants.js
@@ -6,7 +6,8 @@ const HEAD_ENCHANTS = {
         Haste: 10
     },
     Phase: 1,
-    icon: 'inv_misc_gem_02'
+    icon: 'inv_misc_gem_02',
+    desc: '+10 Haste'
   },
   24162: {
     name: "Falcon's Call",
@@ -15,7 +16,8 @@ const HEAD_ENCHANTS = {
       Stam: 10,
       Hit: 10,
       RAP: 24
-    }
+    },
+    desc: '+10 Stam, +10 Hit, +24 RAP'
   },
   35452: {
     name: 'Glyph of Ferocity',
@@ -26,7 +28,8 @@ const HEAD_ENCHANTS = {
         Hit: 16
     },
     Phase: 1,
-    icon: 'classic_ability_druid_demoralizingroar'
+    icon: 'classic_ability_druid_demoralizingroar',
+    desc: '+34 AP, +16 Hit'
   },
   35453: {
     name: 'Glyph of the Gladiator',
@@ -36,7 +39,8 @@ const HEAD_ENCHANTS = {
         Resil: 20
     },
     Phase: 5,
-    icon: 'inv_misc_statue_04'
+    icon: 'inv_misc_statue_04',
+    desc: '+18 Stam, +20 Resil'
   },
   44968: {
     name: 'Heavy Knothide Armor Kit',
@@ -45,7 +49,8 @@ const HEAD_ENCHANTS = {
       Stam: 10
     },
     Phase: 1,
-    icon: 'inv_misc_armorkit_25'
+    icon: 'inv_misc_armorkit_25',
+    desc: '+10 Stam'
   },
   15402: {
     name: 'Lesser Arcanum of Voracity',
@@ -54,7 +59,8 @@ const HEAD_ENCHANTS = {
       Agi: 8
     },
     Phase: 1,
-    icon: 'inv_misc_gem_03'
+    icon: 'inv_misc_gem_03',
+    desc: '+8 Agi'
   },
 }
 
@@ -68,7 +74,8 @@ const SHOULDER_ENCHANTS = {
       Crit: 15
     },
     Phase: 1,
-    icon: 'spell_holy_weaponmastery'
+    icon: 'spell_holy_weaponmastery',
+    desc: '+20 AP, +15 Crit'
   },
   35417: {
     name: 'Greater Inscription of Vengeance',
@@ -79,7 +86,8 @@ const SHOULDER_ENCHANTS = {
       Crit: 10
     },
     Phase: 1,
-    icon: 'spell_holy_greaterblessingofkings'
+    icon: 'spell_holy_greaterblessingofkings',
+    desc: '+30 AP, +10 Crit'
   },
   44968: {
     name: 'Heavy Knothide Armor Kit',
@@ -88,7 +96,8 @@ const SHOULDER_ENCHANTS = {
       Stam: 10
     },
     Phase: 1,
-    icon: 'inv_misc_armorkit_25'
+    icon: 'inv_misc_armorkit_25',
+    desc: '+10 Stam'
   },
   35438: {
     name: 'Inscription of the Blade',
@@ -97,7 +106,8 @@ const SHOULDER_ENCHANTS = {
       Crit: 13
     },
     Phase: 1,
-    icon: 'ability_dualwield'
+    icon: 'ability_dualwield',
+    desc: '+13 Crit'
   },
   35407: {
     name: 'Inscription of Vengeance',
@@ -107,7 +117,8 @@ const SHOULDER_ENCHANTS = {
       RAP: 26,
     },
     Phase: 1,
-    icon: 'spell_holy_fistofjustice'
+    icon: 'spell_holy_fistofjustice',
+    desc: '+26 AP'
   },
   29483: {
     name: 'Might of the Scourge',
@@ -118,7 +129,8 @@ const SHOULDER_ENCHANTS = {
       Crit: 14
     },
     Phase: 1,
-    icon: 'spell_shadow_deathpact'
+    icon: 'spell_shadow_deathpact',
+    desc: '+26 AP, +14 Crit'
   },
   24422: {
     name: 'Zandalar Signet of Might',
@@ -128,7 +140,8 @@ const SHOULDER_ENCHANTS = {
       RAP: 30
     },
     Phase: 1,
-    icon: 'inv_misc_armorkit_08'
+    icon: 'inv_misc_armorkit_08',
+    desc: '+30 AP'
   },
 }
 

--- a/js/datastorage.js
+++ b/js/datastorage.js
@@ -77,7 +77,7 @@ function fetchData(){
 
     // gear
     let savedgear = JSON.parse(localStorage.getItem('gear'));
-    //gear = savedgear;
+    gear = savedgear;
     // buffs
     let savedbuffs = JSON.parse(localStorage.getItem('buffs'));
     buffslist = savedbuffs;

--- a/js/gearui.js
+++ b/js/gearui.js
@@ -219,7 +219,6 @@ function gemSelectorDisplay(slotarray){
                 } else {document.getElementById("gem1select").innerHTML = gemselectOptions; 
                 }
                 document.getElementById("gem1select").value = gem1;
-                console.log(gem1);
             }
             if(skt.length < 2){
                 document.getElementById("gem2seldiv").style.display = "none"; 
@@ -365,7 +364,34 @@ function textColorDisplay(slot,array){
 }
 
 function reduceGearArray(){
-    let newbackArray = Object.keys(BACKS).map(key => ({id:key,Name:BACKS[key].name,DPS:'','Δ +/-':'',Location:BACKS[key].Location}));
+    let BACK_STATS = Object.fromEntries(Object.entries(BACKS));
+    for (key in BACK_STATS) { BACK_STATS[key].DPS = 0; BACK_STATS[key].delta = 0;}
+    
+    for (key in BACKS) {
+        BACK_STATS[key].DPS += (BACKS[key].stats.RAP || 0) * statweights.RAP;
+        BACK_STATS[key].DPS += (BACKS[key].stats.MAP || 0) * statweights.MAP;
+        BACK_STATS[key].DPS += (BACKS[key].stats.Crit || 0) * statweights.rangecrit;
+        BACK_STATS[key].DPS += (BACKS[key].stats.Agi || 0) * statweights.agi;
+        BACK_STATS[key].DPS += (BACKS[key].stats.ArP || 0) * statweights.arp;
+        BACK_STATS[key].DPS += (BACKS[key].stats.Hit || 0) * statweights.rangehit;
+        BACK_STATS[key].DPS += (BACKS[key].stats.Haste || 0) * statweights.haste;
+        
+    }
+    let backitem = '' + gear.back.id;
+    let currdpsback = BACK_STATS[backitem].DPS;
+
+    for (key in BACK_STATS) {
+        BACK_STATS[key].delta = BACK_STATS[key].DPS - currdpsback;
+    }
+
+    let newbackArray = Object.keys(BACKS).map(key => ({id:key,Name:BACKS[key].name,
+        DPS:BACK_STATS[key].DPS,
+        'Δ +/-':BACK_STATS[key].delta,
+        Location:BACKS[key].Location
+    }));
+
+    console.log(newbackArray);
+
 }
 
 function gearSlotsDisplay(){

--- a/js/pet.js
+++ b/js/pet.js
@@ -44,38 +44,38 @@ var PETS = [
     { 
         name: 'Ravager',
         dmgmod: 1.1,
-        primary: 'gore',
-        secondary: 'gore',
+        primary: 'Gore',
+        secondary: 'Gore',
     },
     { 
         name: 'Cat',
         dmgmod: 1.1,
-        primary: 'claw',
-        secondary: 'claw',
+        primary: 'Claw',
+        secondary: 'Claw',
     },
     { 
         name: 'Raptor',
         dmgmod: 1.1,
-        primary: 'claw',
-        secondary: 'claw',
+        primary: 'Claw',
+        secondary: 'Claw',
     },
     { 
         name: 'Owl',
         dmgmod: 1.07,
-        primary: 'screech',
-        secondary: 'screech',
+        primary: 'Screech',
+        secondary: 'Screech',
     },
     { 
         name: 'Bat',
         dmgmod: 1.07,
-        primary: 'screech',
-        secondary: 'screech',
+        primary: 'Screech',
+        secondary: 'Screech',
     },
     { 
         name: 'Wind Serpent',
         dmgmod: 1.07,
-        primary: 'lightning breath',
-        secondary: 'lightning breath',
+        primary: 'Lightning Breath',
+        secondary: 'Lightning Breath',
     },
 ];
 var killcommand = {ready:false, timeremaining:0, basecd:5, cooldown:0};
@@ -109,15 +109,15 @@ function petStatsCalc(){
     // spell selection by pet
     let primary = PETS[selectedPet].primary;
     switch (primary){
-        case 'bite': spellindex = 0; break;
-        case 'screech': spellindex = 1; break;
-        case 'claw': spellindex = 2; break;
-        case 'gore': spellindex = 3; break;
-        case 'lightning breath': spellindex = 4; break;
-        case 'thunderstomp': spellindex = 5; break;
-        case 'fire breath': spellindex = 6; break;
-        case 'poison spit': spellindex = 7; break;
-        case 'scorpid poison': spellindex = 8; break;
+        case 'Bite': spellindex = 0; break;
+        case 'Screech': spellindex = 1; break;
+        case 'Claw': spellindex = 2; break;
+        case 'Gore': spellindex = 3; break;
+        case 'Lightning Breath': spellindex = 4; break;
+        case 'Thunderstomp': spellindex = 5; break;
+        case 'Fire Breath': spellindex = 6; break;
+        case 'Poison Spit': spellindex = 7; break;
+        case 'Scorpid Poison': spellindex = 8; break;
     }
     pet.primarycost = PET_SPELLS[spellindex].cost;
 }

--- a/js/player.js
+++ b/js/player.js
@@ -116,8 +116,8 @@ var gear = {
    back: { id: 29994, enchant: 34004 },
    chest: { id: 30139, gems: [30549, 28363, 28119], enchant: 27960 },
    wrist: { id: 29966, gems: [24028], enchant: 34002 },
-   mainhand: { id: 32944, enchant: 23800 },
-   offhand: { id: 29948, enchant: 23800 },
+   mainhand: { id: 32944, enchant: 42620 },
+   offhand: { id: 29948, enchant: 42620 },
    hand: { id: 30140, enchant: 25080 },
    waist: { id: 30040, gems: [24028, 24028] },
    leg: { id: 29995, enchant: 35490 },
@@ -291,7 +291,8 @@ function calcBaseStats() {
   // Hit rating and hit chance - split between ranged and melee because of hit scope and crit scope and racial
    let hitrating = GearStats.Hit + BuffStats.Hit + EnchantStats.Hit;
   MeleeHitRating = hitrating + custom.meleehit;
-  RangeHitRating = hitrating + EnchantStats.RangeHit + custom.rangehit;
+  let hitscope = currentgear.stats.RangeHit || 0;
+  RangeHitRating = hitrating + hitscope + custom.rangehit;
    let hit = BaseHitChance + talents.surefooted + BuffStats.HitChance;
   MeleeHitChance = hit + MeleeHitRating / HitRatingRatio; // need dual wield condition
   RangeHitChance = hit + RangeHitRating / HitRatingRatio;
@@ -656,7 +657,7 @@ function rollSpell(attack,specialcrit) {
       if (roll < tmp) return RESULT.MISS;
       tmp += DodgeChance * 100;
       if (roll < tmp) return RESULT.DODGE;
-      tmp += (100 - meleemiss) * crit; // pseudo 2 roll
+      tmp += (100 - meleemiss - DodgeChance) * crit; // pseudo 2 roll
       if (roll < tmp) return RESULT.CRIT;
       return RESULT.HIT;
    }
@@ -1179,7 +1180,7 @@ function potionHandling() {
    let primary = auras.potion.primary;
    let secondary = auras.potion.secondary;
    // use secondary if no primary or if mana below 4k
-   if ((secondary && (currentMana <= 4000)) || !primary && secondary) {
+   if ((secondary && (Mana - currentMana >= 3000))) {
          if (secondaryPotion === 'Fel') {
             auras.potion.timer = 24; // add condition for fel mana
             auras.potion.ticks = 7; // 8 total ticks for fel mana, (0-7)
@@ -1201,9 +1202,12 @@ function potionHandling() {
    else if (primary) {
       auras.potion.timer = 15;
       auras.potion.used = 'Haste';
-      
+   } 
+   else {
+      return false;
    }
    auras.potion.cooldown = 120;
+   return true;
 }
 
 /** rng function for randomizing an integer from 2 values such as the damage range on weapons.

--- a/js/simulation.js
+++ b/js/simulation.js
@@ -424,7 +424,7 @@ function spell_choice_method_A(){
     } 
     else { 
         return "autoshot"; 
-}
+    }
 
 }
 
@@ -459,8 +459,8 @@ function spell_choice_method_B(){
         return "autoshot"; 
     }
 }
-var statweights = { str: 0, agi: 0, int: 0, RAP: 0, rangehit: 0, rangecrit: 0, 
-    haste: 0, arp: 0, MAP: 0, meleehit: 0, meleecrit: 0, expertise: 0, mp5: 0
+var statweights = { str: 0, agi: 0.947, int: 0, RAP: 0.428, rangehit: 1.255, rangecrit: 0.782, 
+    haste: 0.779, arp: 0.161, MAP: 0, meleehit: 0, meleecrit: 0, expertise: 0, mp5: 0
 }
 function statWeightLoop(){
     isStatWeights = true;

--- a/js/spells.js
+++ b/js/spells.js
@@ -12,57 +12,57 @@ var SPELLS = {
 
 const PET_SPELLS = [
     {
-        name:'bite',
+        name:'Bite',
         mindmg: 108,
         maxdmg: 132,
         cd:0,
         cost:35,
     },
     {
-        name:'screech',
+        name:'Screech',
         mindmg: 33,
         maxdmg: 61,
         cost: 20,
     },
     {
-        name:'claw',
+        name:'Claw',
         mindmg: 54,
         maxdmg: 76,
         cost: 25,
     },
     {
-        name:'gore',
+        name:'Gore',
         mindmg: 37,
         maxdmg: 61,
         cost: 25,
     },
     {
-        name:'lightning breath',
+        name:'Lightning Breath',
         mindmg: 99,
         maxdmg: 113,
         sp_coeff: 0.05,
         cost: 50,
     },
     {
-        name:'thunderstomp',
+        name:'Thunderstomp',
         mindmg: 115,
         maxdmg: 133,
         sp_coeff: 0.05,
         cost: 60,
     },
     {
-        name:'fire breath',
+        name:'Fire Breath',
         tick: 37,
         sp_coeff: 0.05,
         cost: 50,
     },
     {
-        name:'poison spit',
+        name:'Poison Spit',
         tick: 24,
         cost: 35,
     },
     {
-        name:'scorpid poison',
+        name:'Scorpid Poison',
         tick: 11,
         sp_coeff: 0.026,
         cost: 30,
@@ -106,7 +106,7 @@ function updateSpellCDs(spell,petspell) {
 }
 
 /*************************************************************************/
-/* All formulas below are tested and confirmed in-game as of patch 2.5.2 */
+/* All formulas below are tested and confirmed in-game as of patch 2.5.3 */
 /*************************************************************************/
 
 function autoShotCalc(range_wep, combatRAP) {

--- a/js/stats.js
+++ b/js/stats.js
@@ -1,25 +1,12 @@
-var spreaddata = {
-  labels: [
-    "0",
-    "1",
-    "2",
-    "3",
-    "4"
-  ],
-  datasets: [{
-      data: [
-        2820,
-        2830,
-        2840,
-        2850,
-        2870
-      ],
-      backgroundColor: 'rgba(170,	211, 114, 0.6)',
-      borderColor: 'rgb(170,	211, 114)',
-      borderWidth: 1,
-      barPercentage: 1,
-      categoryPercentage: 1,
-  }]
+var spreaddata = {};
+var actions = {
+  auto: "Auto Shot",
+  arcane: "Arcane Shot",
+  steady: "Steady Shot",
+    multi: "Multi Shot",
+    attack: "Attack (Pet)",
+    kc: "Kill Command (Pet)",
+    primary: "Primary (Pet)"
 };
 
 function buildData(spread){
@@ -109,7 +96,7 @@ var histogram = new Chart(ctx, {
             offset: false
           },
           ticks: {
-            stepSize: 50
+            stepSize: 10
           },
           title: {
             display:true,
@@ -216,20 +203,14 @@ function damageResults(){
   console.log("total damage: " + sumdmg/iterations);
   console.log("duration: " + (Math.round(sumduration/iterations * 100) / 100));
 }
-var actions = {
-auto: "Auto Shot",
-arcane: "Arcane Shot",
-steady: "Steady Shot",
-  multi: "Multi Shot",
-  attack: "Attack (Pet)",
-  kc: "Kill Command (Pet)",
-  primary: "Primary (Pet)",
-};
+
 function buildTable(results){
+  actions.primary = PETS[selectedPet].primary + " (Pet)";
 
   let act = '';
   let tbody = document.getElementById('tbody');
   tbody.innerHTML = '';
+  
   for (var i = 0; i < results.length; i++) {
     let tr = "<tr>";
     if (results[i].results.dps > 0) {
@@ -249,7 +230,7 @@ function buildTable(results){
     }
   }
 }
-
+/** Compares the values of 2 numbers for sorting */
 function compare(a, b) {
   // Use toUpperCase() to ignore character casing
   const dpsA = a.results.dps;

--- a/js/ui.js
+++ b/js/ui.js
@@ -71,45 +71,71 @@ function displayStatWeights(){
 }
 // initialize stats display
 displayStats();
+displayStatWeights();
 
-// Get the modal
-var settingmodal = document.getElementById("settingsmodal");
-// Get the button that opens the modal
-var settingbtn = document.getElementById("settingsbtn");
-// Get the <span> element that closes the modal
-var settingspan = document.getElementsByClassName("close")[0];
-// When the user clicks the button, open the modal 
-settingbtn.onclick = function() {
-    settingmodal.style.display = "block";
-}
-// When the user clicks on <span> (x), close the modal
-settingspan.onclick = function() {
-    settingmodal.style.display = "none";
-}
-// When the user clicks anywhere outside of the modal, close it
-window.onclick = function(event) {
-  if (event.target == settingmodal) {
-    settingmodal.style.display = "none";
-  }
-  if (event.target == logmodal) {
-    logmodal.style.display = "none";
-  }
-  if (event.target == gearmodal) {
-      gearmodal.style.display = "none";
-  }
+function initializeModals(){
+    // Get the modal
+    let settingmodal = document.getElementById("settingsmodal");
+    // Get the button that opens the modal
+    let settingbtn = document.getElementById("settingsbtn");
+    // Get the <span> element that closes the modal
+    let settingspan = document.getElementsByClassName("close")[0];
+    // When the user clicks the button, open the modal 
+    settingbtn.onclick = function() {
+        settingmodal.style.display = "block";
+    }
+    // When the user clicks on <span> (x), close the modal
+    settingspan.onclick = function() {
+        settingmodal.style.display = "none";
+    }
+
+    // Get the modal
+    let importmodal = document.getElementById("importmodal");
+    // Get the button that opens the modal
+    let importbtn = document.getElementById("importbtn");
+    // Get the <span> element that closes the modal
+    let importspan = document.getElementsByClassName("close")[3];
+    // When the user clicks the button, open the modal 
+    importbtn.onclick = function() {
+        importmodal.style.display = "block";
+    }
+    // When the user clicks on <span> (x), close the modal
+    importspan.onclick = function() {
+        importmodal.style.display = "none";
+    }
+
+    let logmodal = document.getElementById("logmodal");
+    // When the user clicks anywhere outside of the modal, close it
+    window.onclick = function(event) {
+        if (event.target == settingmodal) {
+            settingmodal.style.display = "none";
+        }
+        if (event.target == logmodal) {
+            logmodal.style.display = "none";
+        }
+        if (event.target == gearmodal) {
+            gearmodal.style.display = "none";
+        }
+        if (event.target == importmodal) {
+            importmodal.style.display = "none";
+        }
+    }
 }
 
-var logmodal = document.getElementById("logmodal");
-// Get the button that opens the modal
-var logbtn = document.getElementById("logbtn");
-// Get the <span> element that closes the modal
-var logspan = document.getElementsByClassName("close")[1];
-// When the user clicks on <span> (x), close the modal
-logspan.onclick = function() {
-    logmodal.style.display = "none";
-}
+
+
+initializeModals();
 
 function combatLogDisplay(){
+    let logmodal = document.getElementById("logmodal");
+    // Get the <span> element that closes the modal
+    let logspan = document.getElementsByClassName("close")[1];
+    // When the user clicks on <span> (x), close the modal
+
+    logspan.onclick = function() {
+        logmodal.style.display = "none";
+    }
+
     let logbtn = document.getElementById("logbtn");
     if(combatlogarray.length === 0){
         
@@ -146,6 +172,30 @@ function removeZeros(){
     
     filteredbuffs = buffslist.filter(filterById);
 }
+
+function submitImportData() {
+
+    let importedgear = document.getElementById("importdata").value;
+    
+    try {
+        let importdata = JSON.parse(importedgear);
+        let newgear = importFrom70U(importdata);
+        console.log(newgear);
+        // initialize ammo before re-writing
+        newgear.gear.ammo.id = gear.ammo.id;
+        gear = newgear.gear;
+
+        document.getElementById("importdata").value = '';
+        document.getElementById("confirmimport").innerHTML = "Successfully Imported!";
+        selectedOptionsResults();
+    }
+    catch(err){
+        document.getElementById("confirmimport").innerHTML = "Failed to import.. Check copied data and try again.";
+        console.log(err);
+    }
+    
+}
+
 // called each time buffs change to filter zeros, get, recalc, and display them
 function selectedOptionsResults(){
     removeZeros();


### PR DESCRIPTION
- Added Import functionality of 70U links
- adjusted how potions were handled, now always uses mana pot if selected based on threshold not offset (may make threshold adjustable later, currently if missing mana > 3000)
- added descriptions to some enchants (will add more later, gems too for display)
- added back loading saved gear on-load. Now keeps any changes to active gear sets until changed
- made attempt at creating a table for a slot, seems kinda convoluted so getting another opinion
- changed pet spell names to capitalized and changed stats output for pets to say "Spell (Pet)" instead of "Primary (Pet)", where 'Spell' is the pet spell used. i.e. gore, bite, etc.
- changed base gear to include 20 agi to weps
- fixed ranged hit from biznicks to properly add 30 hit rating
- added dodge to any spell melee's for 2 roll calcs on crit
- added default stat weights based on sheet sim results (p2 bis) for now
- now displays the default stat weights used
- wrapped my modals in a function instead of part of the initial scan and made the variables local only