### PR TITLE
Melee weaving and reworked sim logic 

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
     <script class="u-script" type="text/javascript" src="js/auras.js"></script>
     <script class="u-script" type="text/javascript" src="js/pet.js"></script>
     <script class="u-script" type="text/javascript" src="js/player.js"></script>
+    <script class="u-script" type="text/javascript" src="js/expected_dmg.js"></script>
     
     <meta name="generator" content="Nicepage 3.28.7, nicepage.com">
     <script>const whTooltips = {colorLinks: true, iconizeLinks: false, renameLinks: true};</script>
@@ -124,7 +125,7 @@
                   <p class="Stats u-align-right u-text u-text-custom-color-4 u-text-16" id="exp">0</p>
                   <p class="Stats u-align-right u-text u-text-custom-color-4 u-text-17" id="mp5">0</p>
                   <a href="javascript:;" id="settingsbtn" class="u-border-2 u-border-black u-border-hover-black u-btn u-btn-round u-button-style u-custom-color-2 u-hover-white u-radius-5 u-btn-1">Settings</a>
-                  <a href="javascript:;" onclick="startStepOnly()" class="u-border-2 u-border-black u-border-hover-black u-btn u-btn-round u-button-style u-custom-color-2 u-hover-white u-radius-5 u-btn-2">Sim DPS - Step</a>
+                  <a href="javascript:;" class="u-border-2 u-border-black u-border-hover-black u-btn u-btn-round u-button-style u-custom-color-2 u-hover-white u-radius-5 u-btn-2">Sim Soon</a>
                   <a href="javascript:;" onclick="startSync()" id="simdps" class="u-border-2 u-border-black u-border-hover-black u-btn u-btn-round u-button-style u-custom-color-2 u-hover-white u-radius-5 u-btn-3">Sim DPS - Loop<div class="loadbar" id="loadbar"></div></a>
                   <a href="javascript:;" onclick="combatLogDisplay()" onmouseover="combatLogDisplay()" id="logbtn" class="u-border-2 u-border-black u-border-hover-black u-btn u-btn-round u-button-style u-custom-color-2 u-hover-white u-radius-5 u-btn-6">Combat Log</a>
                   <p class="u-align-right u-text u-text-custom-color-7 u-text-18 u-text-1819" id="dpsresult">2000.1</p>
@@ -804,7 +805,7 @@
           </li>
           <img class="spells-image spells-image-10" src="https://wow.zamimg.com/images/wow/icons/large/spell_shadow_sealofkings.jpg" alt="">
           <li><label class="container container-2">Runes<input id="runecheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
-          <input id="runeoffset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input spells-input-9" value="0" onchange="spellOffsets()">
+          <!--<input id="runeoffset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input spells-input-9" value="0" onchange="spellOffsets()">-->
           <br>
           <img class="spells-image spells-image-11" src="https://wow.zamimg.com/images/wow/icons/large/ability_upgrademoonglaive.jpg" alt="">
           <li><label class="container container-1">Multi-Shot<input id="multicheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>

--- a/js/auras.js
+++ b/js/auras.js
@@ -649,23 +649,13 @@ function onUseSpellCheck(){
         }
     }
     if((auras.potion.primary || auras.potion.secondary) && auras.potion.cooldown === 0 && potionHandling()) {
-        if(combatlogRun) {
+        if(combatlogRun && (secondaryPotion === 'Fel' || auras.potion.used === 'Haste')) {
             combatlogarray[combatlogindex] = steptimeend.toFixed(3) + " - Player used " + auras.potion.used + " Potion";
             combatlogindex++;
         }
     }
-    if(auras.rune.enable && auras.rune.cooldown === 0) {
-        let runemana = rng(900,1500);
-        let prev_mana = currentMana;
-        currentMana = Math.min(currentMana + runemana, Mana);
-        let gain = currentMana - prev_mana;
-        let over = runemana - gain;
-        auras.rune.cooldown = 120;
-        if(combatlogRun) {
-            combatlogarray[combatlogindex] = steptimeend.toFixed(3) + " - Player used rune for " + gain + " Mana (O: " + over + ")";
-            combatlogindex++;
-        }
-    }
+    if(auras.rune.enable && auras.rune.cooldown === 0 && runeHandling()) {}
+    
     if(auras.lust.enable && auras.lust.cooldown === 0){
         auras.lust.timer = (auras.lust.cooldown === 0) ? auras.lust.duration : auras.lust.timer; // set timer
         auras.lust.cooldown = (auras.lust.timer === auras.lust.duration) ? auras.lust.basecd: auras.lust.cooldown; // set cd

--- a/js/data/enchants.js
+++ b/js/data/enchants.js
@@ -576,7 +576,7 @@ const RING_ENCHANTS = {
   27920: {
     name: 'Striking',
     effectId: 2929,
-    special: { rangedmgbonus: 2 },
+    special: { dmgbonus: 2 },
     stats: {},
     Phase: 1,
     icon: 'inv_misc_note_01'

--- a/js/datastorage.js
+++ b/js/datastorage.js
@@ -142,10 +142,10 @@ function fetchData(){
     SPELLS.multishot.enable = multicheck;
     let arcanecheck = JSON.parse(localStorage.getItem('arcanecheck'));
     SPELLS.arcaneshot.enable = arcanecheck;
-    //let raptorcheck = JSON.parse(localStorage.getItem('raptorcheck'));
-    //SPELLS.raptorstrike.enable = raptorcheck;
-    //let meleecheck = JSON.parse(localStorage.getItem('meleecheck'));
-    //SPELLS.melee.enable = meleecheck;
+    let raptorcheck = JSON.parse(localStorage.getItem('raptorcheck'));
+    SPELLS.raptorstrike.enable = raptorcheck;
+    let meleecheck = JSON.parse(localStorage.getItem('meleecheck'));
+    SPELLS.melee.enable = meleecheck;
 
     // spell offsets
     let rapidoffset = localStorage.getItem('rapidoffset');
@@ -288,8 +288,8 @@ function fetchData(){
     document.getElementById("runecheck").checked = auras.rune.enable;
     document.getElementById("multicheck").checked = SPELLS.multishot.enable;
     document.getElementById("arcanecheck").checked = SPELLS.arcaneshot.enable;
-    //document.getElementById("raptorcheck").checked = SPELLS.raptorstrike.enable;
-    //document.getElementById("meleecheck").checked = SPELLS.melee.enable;
+    document.getElementById("raptorcheck").checked = SPELLS.raptorstrike.enable;
+    document.getElementById("meleecheck").checked = SPELLS.melee.enable;
     // spell offsets
     document.getElementById("rapidoffset").value = auras.rapid.offset;
     document.getElementById("beastoffset").value = auras.beastwithin.offset;

--- a/js/expected_dmg.js
+++ b/js/expected_dmg.js
@@ -1,0 +1,174 @@
+let _combatCritChance = 0;
+
+//calculates the estimated haste at +t seconds into the future
+function getHasteRanged(t) {
+   haste = 1;
+   rangespeed = BaseRangeSpeed;
+   let hasterating = HasteRating;
+   
+   hasterating += (auras.drums.timer > t && (auras.drums.type === 'battle')) ? 80 : 0; // battle drums
+   hasterating += ((auras.potion.timer > t) && (auras.potion.used === 'Haste')) ? 400 : 0; // haste potion
+   hasterating += (auras.dragonspine.timer > t) ? 325 : 0; // trinket dst haste
+   hasterating += (auras.abacus.timer > t) ? 264 : 0; // trinket abacus haste
+
+   let berserkspeed = 1 + (30 - (BerserkStartHP - 40) / 3) / 100;    // troll berserking (10-30% in tbc)
+   haste = (auras.berserk.timer > t) ? haste * berserkspeed : haste;  // troll berserking (10-30% in tbc)
+   haste = (auras.lust.timer > t) ? haste * 1.3 : haste; // lust
+
+   let hasteRatingSpeed = (hasterating / HasteRatingRatio / 100) + 1;
+   haste *= hasteRatingSpeed;
+
+   // ranged only
+   rangespeed = (auras.rapid.timer > t) ? rangespeed / 1.4 : rangespeed; // rapid fire
+   rangespeed = (auras.imphawk.timer > t) ? rangespeed / talents.imp_hawk : rangespeed; // quick shots
+
+   rangespeed = rangespeed / haste;
+
+   return rangespeed;
+}
+
+function getHasteMelee(t) {
+   haste = 1;
+   meleespeed = BaseMeleeSpeed;
+   let hasterating = HasteRating;
+   
+   hasterating += (auras.drums.timer > t && (auras.drums.type === 'battle')) ? 80 : 0; // battle drums
+   hasterating += ((auras.potion.timer > t) && (auras.potion.used === 'Haste')) ? 400 : 0; // haste potion
+   hasterating += (auras.dragonspine.timer > t) ? 325 : 0; // trinket dst haste
+   hasterating += (auras.abacus.timer > t) ? 264 : 0; // trinket abacus haste
+
+   let berserkspeed = 1 + (30 - (BerserkStartHP - 40) / 3) / 100;    // troll berserking (10-30% in tbc)
+   haste = (auras.berserk.timer > t) ? haste * berserkspeed : haste;  // troll berserking (10-30% in tbc)
+   haste = (auras.lust.timer > t) ? haste * 1.3 : haste; // lust
+
+   let hasteRatingSpeed = (hasterating / HasteRatingRatio / 100) + 1;
+   haste *= hasteRatingSpeed;
+
+   // melee only
+   meleespeed = (auras.mongoose.timer > t) ? meleespeed / 1.02 : meleespeed; // mongoose
+
+   meleespeed = meleespeed / haste;
+
+   return meleespeed;
+}
+
+// handling for dmg mod changes from auras
+function updateDamageMod() {
+   combatdmgmod = 1;
+   physdmgmod = 1;
+   if(auras.beastwithin.timer > 0) { combatdmgmod *= 1.1;} // beast within
+   if(pet.ferocious.timer > 0) { combatdmgmod *= talents.ferocious_insp; } // ferocious insp pet buff
+   if(debuffs.bloodfrenzy.timer > 0 && !debuffs.bloodfrenzy.inactive) { physdmgmod *= 1.04; } // blood frenzy
+   // special mods for non-physical dmg
+
+   return;
+}
+
+
+function exp_dmgMod_Melee() {
+   let remainder = 100;
+   let ff_hit = (debuffs.faeriefire.timer > 0 && debuffs.faeriefire.improved) ? 3 : 0;
+   
+   let meleemiss = Math.max(MeleeMissChance - ff_hit,0);
+   remainder -= meleemiss;
+   
+   let meleedodge = Math.min(remainder, DodgeChance);
+   remainder -= meleedodge;
+   
+   let meleeglance = Math.min(remainder, GlanceChance);
+   remainder -= meleeglance;
+   
+   let meleecrit = Math.min(remainder, MeleeCritChance);
+   remainder -= meleecrit;
+
+   let meleehit = remainder;
+   
+   return mainhand_wep.basedmgmod*0.01*physdmgmod*(MeleeCritDamage*meleecrit + meleehit + GlanceDmgReduction*meleeglance);
+}
+
+function exp_dmgMod_MeleeRaptor() {
+   let remainder = 100;
+   let ff_hit = (debuffs.faeriefire.timer > 0 && debuffs.faeriefire.improved) ? 3 : 0;
+   
+   let meleemiss = Math.max(MeleeMissChance - ff_hit,0);
+   remainder -= meleemiss;
+   
+   let meleedodge = Math.min(remainder, DodgeChance);
+   remainder -= meleedodge;
+   
+   let meleecrit = Math.min(remainder, MeleeCritChance + talents.savage_strikes*10);
+   remainder -= meleecrit;
+
+   let meleehit = remainder;
+
+   return mainhand_wep.basedmgmod*0.01*physdmgmod*(MeleeCritDamage*meleecrit + meleehit);
+}
+
+
+function exp_dmgMod_Physical(critbonus) {
+
+   let ff_hit = (debuffs.faeriefire.timer > 0 && debuffs.faeriefire.improved && !debuffs.faeriefire.inactive) ? 3 : 0;
+   let rangemiss = Math.max(RangeMissChance - ff_hit,0)*0.01;
+   let rangehit = 1 - rangemiss;
+   let rangecrit = (_combatCritChance + critbonus)*0.01;
+   
+   return range_wep.basedmgmod*physdmgmod*combatdmgmod*rangehit*((RangeCritDamage-1)*rangecrit + 1);
+}
+
+function exp_dmgMod_Arcane() {
+
+   let ff_hit = (debuffs.faeriefire.timer > 0 && debuffs.faeriefire.improved && !debuffs.faeriefire.inactive) ? 3 : 0;
+   let rangemiss = Math.max(RangeMissChance - ff_hit,0)*0.01;
+   let rangehit = 1 - rangemiss;
+   let rangecrit = _combatCritChance*0.01;
+   
+   return range_wep.basedmgmod*magdmgmod*combatdmgmod*rangehit*((RangeCritDamage-1)*rangecrit + 1);
+}
+
+function exp_update(){
+   updateAgi();
+   updateAP();
+   updateDamageMod();
+   _combatCritChance = updateCritChance();
+	
+}
+
+function exp_dmg_AutoShot(range_wep, combatRAP){
+
+	let dmg = (range_wep.mindmg + range_wep.maxdmg)*0.5; // avg damage
+    let shotDmg = (range_wep.ammodps * range_wep.speed + combatRAP * range_wep.speed / 14 + dmg + range_wep.flatdmg) * exp_dmgMod_Physical(0);
+    return shotDmg;
+}
+function exp_dmg_SteadyShot(range_wep, combatRAP) {
+
+	let dmg = (range_wep.mindmg + range_wep.maxdmg)*0.5; // avg damage
+    let gronnstalkermod = currentgear.special.gronnstalker_4p_steady_shot_dmg_ratio;
+    let shotDmg = (combatRAP * 0.2 + dmg * 2.8 / range_wep.speed + SPELLS.steadyshot.rankdmg) * exp_dmgMod_Physical(currentgear.special.rift_stalker_4p_ss_crit) * gronnstalkermod;
+    return shotDmg;
+}
+
+function exp_dmg_MultiShot(range_wep, combatRAP) {
+
+	let dmg = (range_wep.mindmg + range_wep.maxdmg)*0.5; // avg damage
+    let multimod = currentgear.special.multishot_dmg_inc_ratio * talents.barrage;
+    let shotDmg = (range_wep.ammodps * range_wep.speed + combatRAP * 0.2 + dmg + range_wep.flatdmg + SPELLS.multishot.rankdmg) * exp_dmgMod_Physical(talents.imp_barrage*4) * multimod;
+    return shotDmg;
+}
+
+function exp_dmg_ArcaneShot(range_wep, combatRAP) {
+
+    let shotDmg = (combatRAP * 0.15 + SPELLS.arcaneshot.rankdmg) * exp_dmgMod_Arcane();
+    return shotDmg;
+}
+
+function exp_dmg_RaptorStrike(mainhand_wep, combatMAP) {
+
+	let dmg = (mainhand_wep.mindmg + mainhand_wep.maxdmg)*0.5; // avg damage
+    return (dmg + mainhand_wep.flatdmg + SPELLS.raptorstrike.rankdmg + combatMAP*mainhand_wep.speed) * combatdmgmod * exp_dmgMod_MeleeRaptor(); 
+}
+
+function exp_dmg_MeleeSwing(mainhand_wep, combatMAP) {
+
+	let dmg = (mainhand_wep.mindmg + mainhand_wep.maxdmg)*0.5; // avg damage
+    return (dmg + mainhand_wep.flatdmg + combatMAP*mainhand_wep.speed) * combatdmgmod * exp_dmgMod_Melee(); 
+}

--- a/js/pet.js
+++ b/js/pet.js
@@ -368,7 +368,7 @@ function petSpell(petspell){
     petUpdateHaste();
     
     if(combatlogRun && petspell === 'kill command') {
-        combatlogarray[combatlogindex] = steptimeend.toFixed(3) + " - Pet " + petspell + " " + RESULTARRAY[result] + " for " + done;
+        combatlogarray[combatlogindex] = steptimeend.toFixed(3) + " - Pet Kill Command " + RESULTARRAY[result] + " for " + done;
         combatlogindex++;
     } else if(combatlogRun){
         combatlogarray[combatlogindex] = petsteptime.toFixed(3) + " - Pet " + PET_SPELLS[spellindex].name + " " + RESULTARRAY[result] + " for " + done;

--- a/js/stats.js
+++ b/js/stats.js
@@ -3,10 +3,12 @@ var actions = {
   auto: "Auto Shot",
   arcane: "Arcane Shot",
   steady: "Steady Shot",
-    multi: "Multi Shot",
-    attack: "Attack (Pet)",
-    kc: "Kill Command (Pet)",
-    primary: "Primary (Pet)"
+  multi: "Multi Shot",
+  raptor: "Raptor Strike",
+  melee: "Melee",
+  attack: "Attack (Pet)",
+  kc: "Kill Command (Pet)",
+  primary: "Primary (Pet)"
 };
 
 function buildData(spread){
@@ -132,6 +134,8 @@ function damageResults(){
       auto: {},
       multi: {},
       arcane: {},
+      raptor: {},
+      melee: {},
       attack: {},
       kc: {},
       primary: {}
@@ -167,6 +171,27 @@ function damageResults(){
       simresults.arcane.hit = (spellresult.arcaneshot.Hit / arcanecount) * 100;
       simresults.arcane.avg = (arcanedmg / arcanecount);
       simresults.arcane.dps = (arcanedmg / sumduration);
+  }
+  //raptor
+  if(SPELLS.raptorstrike.enable){
+      simresults.raptor.casts = (raptorcount / iterations);
+      simresults.raptor.miss = (spellresult.raptorstrike.Miss / raptorcount) * 100;
+      simresults.raptor.dodge = (spellresult.raptorstrike.Dodge / raptorcount) * 100;
+      simresults.raptor.crit = (spellresult.raptorstrike.Crit / raptorcount) * 100;
+      simresults.raptor.hit = (spellresult.raptorstrike.Hit / raptorcount) * 100;
+      simresults.raptor.avg = (raptordmg / raptorcount);
+      simresults.raptor.dps = (raptordmg / sumduration);
+  }
+  //melee swings
+  if(SPELLS.melee.enable){
+      simresults.melee.casts = (meleecount / iterations);
+      simresults.melee.miss = (spellresult.melee.Miss / meleecount) * 100;
+      simresults.melee.dodge = (spellresult.melee.Dodge / meleecount) * 100;
+      simresults.melee.crit = (spellresult.melee.Crit / meleecount) * 100;
+      simresults.melee.hit = (spellresult.melee.Hit / meleecount) * 100;
+      simresults.melee.glance = (spellresult.melee.Glance / meleecount) * 100;
+      simresults.melee.avg = (meleedmg / meleecount);
+      simresults.melee.dps = (meleedmg / sumduration);
   }
   // pet auto
   simresults.attack.casts = (petautocount / iterations);

--- a/js/ui.js
+++ b/js/ui.js
@@ -158,6 +158,15 @@ function combatLogDisplay(){
     
 }
 
+function filterCombatLog(){
+    filteredcombatlogarray = combatlogarray.filter(key => key.includes("Player") && !key.includes("Mana"));
+    let combatlog = "";
+            for (i=0; i < filteredcombatlogarray.length; i++) {
+                combatlog += "<p>" + filteredcombatlogarray[i] + "</p>";
+            }   
+            document.getElementById("combatlog").innerHTML = combatlog;
+}
+
 combatLogDisplay();
 // filters out ids with 0s for the getStatsFromBuffs formula
 function removeZeros(){
@@ -783,8 +792,8 @@ function spellEnableCheck(){
     let runecheck = document.getElementById("runecheck").checked;
     let multicheck = document.getElementById("multicheck").checked;
     let arcanecheck = document.getElementById("arcanecheck").checked;
-    //let raptorcheck = document.getElementById("raptorcheck").checked;
-    //let meleecheck = document.getElementById("meleecheck").checked;
+    let raptorcheck = document.getElementById("raptorcheck").checked;
+    let meleecheck = document.getElementById("meleecheck").checked;
 
     auras.rapid.enable = rapidcheck;
     beastenable = beastcheck;
@@ -797,8 +806,8 @@ function spellEnableCheck(){
     
     SPELLS.multishot.enable = multicheck;
     SPELLS.arcaneshot.enable = arcanecheck;
-    //SPELLS.raptorstrike.enable = raptorcheck;
-    //SPELLS.melee.enable = meleecheck;
+    SPELLS.raptorstrike.enable = raptorcheck;
+    SPELLS.melee.enable = meleecheck;
     storeData();
 
 }


### PR DESCRIPTION
- moved rune handling to be "smart" and use your mana pool instead, so if missing mana below 1500 it uses rune similar to pots now
- commented out the rune offset for now, may delete later
- fixed an issue where Striking enchant only applied to ranged dmg
- added functions for calculating expected dmg for sim logic
- removed step function button, can still run from console command for debugging
- cleaned up spell names to be "proper" with spaces and capitalization in the combatlog
- added DW melee miss penalty if OH selected
- added melee/ranged check for crit procs (some are ranged only)
- added damage calc for melee and raptor strike
- added filterCombatLog function for testing future filtering
- added spell cast starts for steady, auto, multi + next GCD and cast time
- added better logic for decision making for spell usage
- added offsets for melee weaving (4s default, may change later) to prevent weaving at the immediate start of a fight (you start at ranged duh)
- added offset for start of fight for multi and arcane for helping enforce rotation starts off the right way (auto -> steady -> blah instead of multi or arc first)
- added melee/raptor to the stats display