### PR TITLE
windfury procs, attachments code, crit calc fix for melee

### DIFF
--- a/js/auras.js
+++ b/js/auras.js
@@ -142,6 +142,8 @@ function initializeAuras() {
     auras.eternalchamp.enable = ((gear.ring1.id === 29301) || (gear.ring2.id === 29301)) ? true : false;
     auras.imphawk.enable = (talents.imp_hawk > 1) ? true : false;
     auras.righteous.enable = temp_oil ? true : false;
+    auras.mongoose.enable = (gear.mainhand.enchant === 27984) ? true : false;
+    auras.executioner.enable = (gear.mainhand.enchant === 42974) ? true : false;
 
     for(let prop in auras){
         auras[prop].uptime = 0;
@@ -405,6 +407,10 @@ function uptimecalc() {
 
     if(debuffs.exposeweakness.timer > 0 && talents.exp_weakness > 0) { debuffs.exposeweakness.uptime += Math.min(debuffs.exposeweakness.timer,steptime); }
     // for debugging debuffs - tracking actual uptime
+    if(debuffs.exposeweakness.timer > 0 && !debuffs.exposeweakness.inactive && talents.exp_weakness === 0) { debuffs.exposeweakness.uptime += steptime; }
+    else if(debuffs.exposeweakness.timer < 0) {
+       debuffs.exposeweakness.uptime += steptime;
+    }
     if(debuffs.hm.timer > 0 && !debuffs.hm.inactive) { debuffs.hm.uptime += steptime; }
     else if(debuffs.hm.timer < 0) {
        debuffs.hm.uptime += steptime;
@@ -570,7 +576,7 @@ function debuffHandler(){
     if(debuffs.hm.timer <= 0 || debuffs.hm.inactive) {debuffs.hm.stacks = 0;} // sets stacks to 0 when inactive
     if((debuffs.hm.timer <= 0) && (debuffs.hm.uptime_g > 0)) { debuffs.hm.timer += debuffSetTime("hm"); } // sets the timer to inactive or active
     
-    if((debuffs.exposeweakness.timer === 0) && (talents.exp_weakness === 0 && debuffs.exposeweakness.uptime_g > 0)) { 
+    if((debuffs.exposeweakness.timer <= 0) && (talents.exp_weakness === 0 && debuffs.exposeweakness.uptime_g > 0)) { 
         debuffs.exposeweakness.timer = debuffSetTime("exposeweakness"); } // sets the timer to inactive or active
 
     if((debuffs.judgewisdom.timer <= 0) && (debuffs.judgewisdom.uptime_g > 0)) { 
@@ -639,6 +645,7 @@ function debuffSetTime(name){
 
 /**Check for on use spells ready and usable, if ready and usable, set the duration and cooldown timers. */
 function onUseSpellCheck(){
+    let beastwithinreduc = (auras.beastwithin.timer > 0) ? 0.8 : 1;
 
     if(auras.drums.enable && auras.drums.cooldown === 0){
         auras.drums.timer = (auras.drums.cooldown === 0) ? auras.drums.duration : auras.drums.timer; // set timer
@@ -664,7 +671,8 @@ function onUseSpellCheck(){
             combatlogindex++;
         }
     }
-    if(auras.rapid.enable && auras.rapid.cooldown === 0){
+    let rapidcost = Math.floor(100 * beastwithinreduc);
+    if(auras.rapid.enable && auras.rapid.cooldown === 0 && currentMana >= rapidcost){
         auras.rapid.timer = (auras.rapid.cooldown === 0) ? auras.rapid.duration : auras.rapid.timer; // set timer
         auras.rapid.cooldown = (auras.rapid.timer === auras.rapid.duration) ? auras.rapid.basecd: auras.rapid.cooldown; // set cd
         if(combatlogRun) {
@@ -673,7 +681,8 @@ function onUseSpellCheck(){
         }
     }
     if(racialenable) {
-        if(auras.berserk.enable && auras.berserk.cooldown === 0){
+        let berserkcost = (auras.berserk.enable) ? Math.floor(0.06 * BaseMana * beastwithinreduc) : 0;
+        if(auras.berserk.enable && auras.berserk.cooldown === 0 && currentMana >= berserkcost){
             auras.berserk.timer = (auras.berserk.cooldown === 0) ? auras.berserk.duration : auras.berserk.timer; // set timer
             auras.berserk.cooldown = (auras.berserk.timer === auras.berserk.duration) ? auras.berserk.basecd: auras.berserk.cooldown; // set cd
             if(combatlogRun) {

--- a/js/data/enchants.js
+++ b/js/data/enchants.js
@@ -757,6 +757,53 @@ const RANGE_ENCHANTS = {
   }
 }
 
+const ATTACHMENTS = {
+  34340: {
+    name: 'Adamantite Weightstone',
+    effectId: 2955,
+    stats: {
+      RangeCrit: 14,
+      MeleeCrit: 14
+    },
+    special: {
+      rangedmgbonus: 12,
+      dmgbonus: 12,
+    },
+    type: 'blunt',
+    Phase: 1,
+    icon: 'inv_stone_weightstone_07'
+  },
+  29453: {
+    name: 'Adamantite Sharpening Stone',
+    effectId: 2713,
+    stats: {
+      MeleeCrit: 14
+    },
+    special: {
+      rangedmgbonus: 12,
+      dmgbonus: 12,
+    },
+    type: 'sharp',
+    Phase: 1,
+    icon: 'inv_stone_sharpeningstone_07'
+  },
+  28013: {
+    name: 'Superior Mana Oil',
+    effectId: 2677,
+    stats: {
+      MP5: 14
+    },
+    Phase: 1,
+    icon: 'inv_potion_101'
+  },
+  45397: {
+    name: 'Righteous Weapon Coating',
+    effectId: 3266,
+    Phase: 1,
+    icon: 'inv_potion_101'
+  },
+}
+
 const ENCHANT_MAP = {
   back: BACK_ENCHANTS,
   chest: CHEST_ENCHANTS,
@@ -770,5 +817,6 @@ const ENCHANT_MAP = {
   ring1: RING_ENCHANTS,
   ring2: RING_ENCHANTS,
   shoulder: SHOULDER_ENCHANTS,
-  wrist: WRIST_ENCHANTS
+  wrist: WRIST_ENCHANTS,
+  attachment: ATTACHMENTS
 };

--- a/js/datastorage.js
+++ b/js/datastorage.js
@@ -299,7 +299,7 @@ function fetchData(){
     document.getElementById("trink1offset").value = auras.aptrink1.offset;
     document.getElementById("trink2offset").value = auras.aptrink2.offset;
     document.getElementById("startpotoffset").value = auras.potion.offset;
-    document.getElementById("runeoffset").value = auras.rune.offset;
+    //document.getElementById("runeoffset").value = auras.rune.offset;
     // spell options
     document.getElementById("lustoption").value = lustoption;
     document.getElementById("drumoption").value = auras.drums.type;

--- a/js/spells.js
+++ b/js/spells.js
@@ -136,14 +136,14 @@ function updateSpellCDs(spell,petspell) {
 
 function autoShotCalc(range_wep, combatRAP) {
 
-    let dmg = rng(range_wep.mindmg,range_wep.maxdmg);
+    let dmg = (useAverages) ? (range_wep.mindmg + range_wep.maxdmg) * 0.5 : rng(range_wep.mindmg,range_wep.maxdmg);
     let shotDmg = (range_wep.ammodps * range_wep.speed + combatRAP * range_wep.speed / 14 + dmg + range_wep.flatdmg) * range_wep.basedmgmod * combatdmgmod * physdmgmod;
     return shotDmg;
 }
 
 function steadyShotCalc(range_wep, combatRAP) {
 
-    let dmg = rng(range_wep.mindmg,range_wep.maxdmg);
+    let dmg = (useAverages) ? (range_wep.mindmg + range_wep.maxdmg) * 0.5 : rng(range_wep.mindmg,range_wep.maxdmg);
     let gronnstalkermod = currentgear.special.gronnstalker_4p_steady_shot_dmg_ratio;
     let shotDmg = (combatRAP * 0.2 + dmg * 2.8 / range_wep.speed + SPELLS.steadyshot.rankdmg) * range_wep.basedmgmod * gronnstalkermod * combatdmgmod * physdmgmod;
     return shotDmg;
@@ -151,7 +151,7 @@ function steadyShotCalc(range_wep, combatRAP) {
 
 function multiShotCalc(range_wep, combatRAP) {
 
-    let dmg = rng(range_wep.mindmg,range_wep.maxdmg);
+    let dmg = (useAverages) ? (range_wep.mindmg + range_wep.maxdmg) * 0.5 : rng(range_wep.mindmg,range_wep.maxdmg);
     let multimod = currentgear.special.multishot_dmg_inc_ratio * talents.barrage;
     let shotDmg = (range_wep.ammodps * range_wep.speed + combatRAP * 0.2 + dmg + range_wep.flatdmg + SPELLS.multishot.rankdmg) * range_wep.basedmgmod * multimod * combatdmgmod * physdmgmod;
     return shotDmg;
@@ -166,33 +166,33 @@ function arcaneShotCalc(range_wep, combatRAP) {
 
 function aimedShotCalc(range_wep, combatRAP) {
 
-    let dmg = rng(range_wep.mindmg,range_wep.maxdmg);
+    let dmg = (useAverages) ? (range_wep.mindmg + range_wep.maxdmg) * 0.5 : rng(range_wep.mindmg,range_wep.maxdmg);
     let shotDmg = (range_wep.ammodps * range_wep.speed + combatRAP * 0.2 + dmg + range_wep.flatdmg + SPELLS.aimedshot.rankdmg) * range_wep.basedmgmod * combatdmgmod * physdmgmod;
     return shotDmg;
 }
 
 function raptorStrikeCalc(mainhand_wep, combatMAP) {
 
-    let dmg = rng(mainhand_wep.mindmg, mainhand_wep.maxdmg);
-    let outDmg = (dmg + mainhand_wep.flatdmg + SPELLS.raptorstrike.rankdmg + combatMAP/14*mainhand_wep.speed) * mainhand_wep.basedmgmod * combatdmgmod * physdmgmod;
+    let dmg = (useAverages) ? (mainhand_wep.mindmg + mainhand_wep.maxdmg) * 0.5 : rng(mainhand_wep.mindmg,mainhand_wep.maxdmg);
+    let outDmg = (combatMAP * mainhand_wep.speed / 14 + dmg + mainhand_wep.flatdmg + SPELLS.raptorstrike.rankdmg) * mainhand_wep.basedmgmod * combatdmgmod * physdmgmod;
     return outDmg;
 }
 
 function meleeStrikeCalc(mainhand_wep, combatMAP) {
 
-    let dmg = rng(mainhand_wep.mindmg, mainhand_wep.maxdmg);
-    let outDmg = (dmg + mainhand_wep.flatdmg + combatMAP/14*mainhand_wep.speed) * mainhand_wep.basedmgmod * combatdmgmod * physdmgmod;
+    let dmg = (useAverages) ? (mainhand_wep.mindmg + mainhand_wep.maxdmg) * 0.5 : rng(mainhand_wep.mindmg,mainhand_wep.maxdmg);
+    let outDmg = (combatMAP * mainhand_wep.speed / 14 + dmg + mainhand_wep.flatdmg) * mainhand_wep.basedmgmod * combatdmgmod * physdmgmod;
     return outDmg;
 }
 
 function petAutoCalc(){
-    let dmg = rng(PetMinDmg,PetMaxDmg);
+    let dmg = (useAverages) ? (PetMinDmg + PetMaxDmg) * 0.5 : rng(PetMinDmg,PetMaxDmg);
     let autoDmg = (dmg + pet.combatap * 2 / 14) * pet.dmgmod * pet.combatdmgmod * CobraReflexesPenalty;
     return autoDmg;
 }
 
 function petKillCommCalc(){
-    let dmg = rng(PetMinDmg,PetMaxDmg);
+    let dmg = (useAverages) ? (PetMinDmg + PetMaxDmg) * 0.5 : rng(PetMinDmg,PetMaxDmg);
     let kcDmg = (dmg + pet.combatap * 2 / 14 + 127) * pet.dmgmod * pet.combatdmgmod;
     return kcDmg;
 }
@@ -207,13 +207,13 @@ function spellPetCalc(spellindex){
     if(spellindex <= 3){ // phys spells
         mindmg = PET_SPELLS[spellindex].mindmg; // min dmg of phys spell selected
         maxdmg = PET_SPELLS[spellindex].maxdmg; 
-        dmg = rng(mindmg,maxdmg);
+        dmg = (useAverages) ? (mindmg + maxdmg) * 0.5 : rng(mindmg,maxdmg);
         spelldmg = dmg * basedmgmod;
     } 
     else if (spellindex <= 5 && spellindex > 3){ // lightning breath/stomp
         mindmg = PET_SPELLS[spellindex].mindmg; // min dmg of phys spell selected
         maxdmg = PET_SPELLS[spellindex].maxdmg; 
-        dmg = rng(mindmg,maxdmg);
+        dmg = (useAverages) ? (mindmg + maxdmg) * 0.5 : rng(mindmg,maxdmg);
         spelldmg = (dmg + spellpwr * PET_SPELLS[spellindex].sp_coeff) * basedmgmod;
     } 
     else if (spellindex === 6) { // fire breath
@@ -232,10 +232,14 @@ function spellPetCalc(spellindex){
 
     // gore bonus dmg
     if(spellindex === 3) {
-        let roll = rng10k();
-        if(roll < 5000) {
-            spelldmg *= 2;
+        let roll = 0;
+        if (!useAverages) { 
+            roll = rng10k();
+            if(roll < 5000) {
+                spelldmg *= 2;
+            }
         }
+        else { spelldmg *= 1.5; } // use 150% damage instead of rolling 50% double dmg
     }
     return spelldmg;
 }

--- a/js/statCalculator.js
+++ b/js/statCalculator.js
@@ -201,6 +201,26 @@ function getStatsFromEnchants(gear) {
   }, { stats: {}, special: { incWeapDmg: 0, moveSpeed: 1 }, auras: {} })
 }
 
+/** Given the gear object, calculates stats, auras and special values obtained from enchants */
+function getStatsFromAttachments(gear) {
+  return Object.entries(gear).reduce((result, [type, gearData]) => {
+    const attachmentId = gearData.attachment
+
+    if (attachmentId) {
+      if (!ENCHANT_MAP.attachment) throw Error(`Detected attachment for piece of type "${type}", which can't be attached`)
+      if (!ENCHANT_MAP.attachment[attachmentId]) throw Error(`Detected invalid attachment with id "${attachmentId}" for piece of type "${type}"`)
+
+      const attachment = ENCHANT_MAP.attachment[attachmentId]
+
+      if (attachment.stats) sumStats(attachment.stats, result.stats)
+      if (attachment.aura) result.auras[enchantId] = attachment.aura
+      if (attachment.special) addSpecial(attachment.special, result.special)
+    }
+
+    return result
+  }, { stats: {}, special: { incWeapDmg: 0, moveSpeed: 1 }, auras: {} })
+}
+
 /* Given the amount of pieces used for each set, calculates bonuses provided by each set.
    It loops over all the sets so it can provide default values */
 function getSetBonuses(setPieces) {
@@ -267,6 +287,7 @@ function getStatsFromGear(gear) {
   const result = getStatsFromGearPieces(gear)
   mergeResults(getStatsFromGems(gear), result)
   mergeResults(getStatsFromEnchants(gear), result)
+  mergeResults(getStatsFromAttachments(gear), result)
 
   return result
 }

--- a/js/stats.js
+++ b/js/stats.js
@@ -281,10 +281,10 @@ function resultCountInitialize() {
       if (spellname === 'primary') {
           spellresult[spellname].Partial = 0;
       }
-      if (spellname === 'primary' || 'petattack' || 'killcommand') {
+      if (spellname === 'primary' || 'petattack' || 'killcommand' || 'raptorstrike' || 'melee') {
           spellresult[spellname].Dodge = 0;
       }
-      if (spellname === 'petattack') {
+      if (spellname === 'petattack' || 'melee') {
           spellresult[spellname].Glance = 0;
       }
 


### PR DESCRIPTION
- added weapon attachments to the enchants list
- fixed an issue where mongoose and executioner would not enable when selected
- fixed an issue where expose weakness was not applying after the first application when using the debuff instead of the talents
- added rapid fire and berserking mana costs when cast
- changed baseMana to 3383 from 3253, and adjusted mana formula
- added melee crit from stones if selected
- fixed an issue where +dmg bonuses weren't applying
- completely redid how crit was handled in combat - now checks for melee or ranged and returns a crit value to be used for rolls
- moved melee swing calc to it's own function for usability with extra attacks
- redid cost calculations for mana to be per spell with each spells' adjustments
- added talent "Resourcefulness" for raptor strike cost reduction
- added windfury procs option if windfury enabled
- adjusted how player start time is handled
- fixed kill command to properly proc judgement of wisdom
- expanded stat weights calc
- added an "Averages" option for spell damage calculations in an attempt to help reduce time to calculate. No current toggle yet. Spell damage range is averaged, along with jow
- added sum for attachment stats
- added some attack results to melee/windfury on the display since they weren't being totaled properly