### PR TITLE
party buffs

### DIFF
--- a/css/Main.css
+++ b/css/Main.css
@@ -318,7 +318,14 @@ td {
   min-height: 539px;
   margin: -25px auto 0 756px;
 }
-
+.weightloadbar {
+  position:absolute;
+  width: 0%;
+  height: 5px;
+  top:45px;
+  left: 0px;
+  background-color: #ff9900;
+}
 .loadbar {
   position:absolute;
   width: 0%;
@@ -553,7 +560,20 @@ td {
   word-wrap: normal;
   margin: 0px 0px 0px 0px;
 }
-
+.u-section-1 .meta-req-met {
+  font-size: 0.75rem;
+  font-style: italic;
+  word-wrap: normal;
+  margin: 0px 0px 0px 0px;
+  color:#1fed03;
+}
+.u-section-1 .meta-req-fail {
+  font-size: 0.75rem;
+  font-style: italic;
+  word-wrap: normal;
+  margin: 0px 0px 0px 0px;
+  color:darkgrey;
+}
 .u-section-1 .attach-name {
   font-size: 0.75rem;
   font-style: italic;

--- a/css/Main.css
+++ b/css/Main.css
@@ -659,6 +659,14 @@ td {
   font-weight: 700;
 }
 
+.relative-wrapper {
+  position: relative;
+}
+.relative-wrapper-spells {
+  position: relative;
+  top: 15px;
+}
+
 @media (max-width: 100px) {
   .u-section-1 .u-sheet-1 {
     min-height: 1033px;

--- a/css/settings.css
+++ b/css/settings.css
@@ -937,6 +937,13 @@ ul {
   border: 0.125rem solid rgb(30, 255, 0);
 }
 
+.sktrecommend {
+  color: rgb(30, 255, 0);
+  position: relative;
+  top: 0;
+  left: 0;
+}
+
 .searchfield {
   color: rgb(255, 255, 255);
   height: 2.5rem;

--- a/css/settings.css
+++ b/css/settings.css
@@ -170,6 +170,15 @@ ul {
   font-size: 14px;
 
 }
+.label-9 {
+  position: relative;
+  display: inline-block;
+  color: white;
+  top: 0px;
+  left: 2%;
+  vertical-align: center;
+  font-size: 12px;
+}
 .label-filter {
   position: relative;
   text-align: middle;
@@ -326,6 +335,10 @@ ul {
     vertical-align: middle;
     width: 15%;
   }
+
+  .container-adjust-top {
+      top: 0px;
+    }
   /* Hide the browser's default checkbox */
   .container input {
     position: absolute;
@@ -466,61 +479,73 @@ ul {
   /* Reset */
   width: 120px;
   left: 3px;
-
+  z-index: 1;
 }
 .select-1 {
   float: right;
   right: 40px;
+  z-index: 1;
   }
 .select-2 {
   float: right;
   right: 40px;
-
+  z-index: 1;
 }
 .select-3 {
   position: absolute;
-  top: 160px; /*158px*/
+  top: -12px;
   height: 48px;
   float: right;
-  right: 44px;
-
+  right: 38px;
+  z-index: 1;
 }
 .select-4 {
   float: right;
   right: 40px;
+  z-index: 1;
 }
 .select-5 {
   /* Reset */
   float: right;
   right: 40px;
+  z-index: 1;
 }
 .select-6 {
   float: right;
   right: 40px;
+  z-index: 1;
 }
 .select-7 {
     /* Reset */
     float: right;
   right: 40px;
+  z-index: 1;
 
 }
 .select-8 {
   /* Reset */
   float: right;
   right: 40px;
-
+  z-index: 1;
 }
-.select-9 {
+.select-imp-auras-2 {
   /* Reset */
   left: -7px;
+  z-index: 1;
+}
 
+.select-imp-auras {
+  top: -26px;
+  left: 100px;
+  position: absolute;
+  z-index: 1;
 }
 
 .select-10 {
   /* Reset */
   float: right;
   right: 40px;
-
+  z-index: 1;
 }
 .select-relative {
     position: relative;
@@ -537,127 +562,15 @@ ul {
   font-weight: 600;
 }
 
-.settings-image-1 {
+.settings-image-buffs {
   position: absolute;
-  left: 5px;
-  top: 42px;
-  width: 22px;
-  height: auto;
-}
-.settings-image-2 {
-  position: absolute;
-  left: 5px;
-  top: 71px;
-  width: 22px;
-  height: auto;
-}
-.settings-image-3 {
-  position: absolute;
-  left: 5px;
-  top:  100px;
-  width: 22px;
-  height: auto;
-}
-.settings-image-4 {
-  position: absolute;
-  left: 5px;
-  top: 130px;
-  width: 22px;
-  height: auto;
-}
-.settings-image-5 {
-  position: absolute;
-  left: 5px;
-  top: 159px;
-  width: 22px;
-  height: auto;
-}
-.settings-image-6 {
-  position: absolute;
-  left: 5px;
-  top: 187px;
-  width: 22px;
-  height: auto;
-}
-.settings-image-7 {
-  position: absolute;
-  left: 5px;
-  top: 215px;
-  width: 22px;
-  height: auto;
-}
-.settings-image-8 {
-  position: absolute;
-  left: 5px;
-  top: 243px;
-  width: 22px;
-  height: auto;
-}
-.settings-image-9 {
-  position: absolute;
-  left: 5px;
-  top: 274px;
-  width: 22px;
-  height: auto;
-}
-.settings-image-10 {
-  position: absolute;
-  left: 5px;
-  top: 303px;
-  width: 22px;
-  height: auto;
-}
-.settings-image-11 {
-  position: absolute;
-  left: 5px;
-  top: 331px;
-  width: 22px;
-  height: auto;
-}
-.settings-image-12 {
-  position: absolute;
-  left: 5px;
-  top: 360px;
-  width: 22px;
-  height: auto;
-}
-.settings-image-13 {
-  position: absolute;
-  left: 5px;
-  top: 390px;
-  width: 22px;
-  height: auto;
-}
-.settings-image-14 {
-  position: absolute;
-  left: 5px;
-  top: 419px;
-  width: 22px;
-  height: auto;
-}
-.settings-image-15 {
-  position: absolute;
-  left: 5px;
-  top: 449px;
-  width: 22px;
-  height: auto;
-}
-.settings-image-16 {
-  position: absolute;
-  left: 5px;
-  top: 477px;
-  width: 22px;
-  height: auto;
-}
-.settings-image-17 {
-  position: absolute;
-  left: 5px;
-  top: 505px;
+  left: -22px;
+  top: 16px;
   width: 22px;
   height: auto;
 }
 
-.settings-image-18 {
+.settings-image-auras {
   position: relative;
   left: -20px;
   top: 6px;
@@ -671,51 +584,10 @@ ul {
 }
 .spells-image {
   position: absolute;
-  left: -2px;
+  left: -22px;
+  top: 0px;
   width: 22px;
   height: auto;
-}
-.spells-image-1 {
-  top: 16px;
-}
-.spells-image-2 {
-  top: 44px;
-}
-.spells-image-3 {
-  top:  72px;
-}
-.spells-image-4 {
-  top: 101px;
-}
-.spells-image-5 {
-  top: 131px;
-}
-.spells-image-6 {
-  top: 160px;
-}
-.spells-image-7 {
-  top: 188px;
-}
-.spells-image-8 {
-  top: 253px;
-}
-.spells-image-9 {
-  top: 282px;
-}
-.spells-image-10 {
-  top: 312px;
-}
-.spells-image-11 {
-  top: 365px;
-}
-.spells-image-12 {
-  top: 393px;
-}
-.spells-image-13 {
-  top: 421px;
-}
-.spells-image-14 {
-  top: 449px;
 }
 
 .spell-option-1 {
@@ -734,6 +606,7 @@ ul {
 .spells-input {
   position: absolute;
   left: 72%;
+  top: 0px;
   width: 50px;
   text-align: center;
 }
@@ -770,24 +643,28 @@ ul {
   /* Reset */
   width: 95px;
   left: 20%;
+  z-index: 1;
 }
 
 .select-spell-option-2 {
   /* Reset */
   width: 95px;
   left: 25.2%;
+  z-index: 1;
 }
 
 .select-spell-option-3 {
   /* Reset */
   width: 95px;
   left: 9.4%;
+  z-index: 1;
 }
 
 .select-spell-option-4 {
   /* Reset */
   width: 95px;
   left: 4.5%;
+  z-index: 1;
 }
 
 .spell-label-1 {

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
                 <div class="u-container-layout u-container-layout-1">
                   
                   <a href="javascript:;" id="settingsbtn" class="u-border-2 u-border-black u-border-hover-black u-btn u-btn-round u-button-style u-custom-color-2 u-hover-white u-radius-5 u-btn-1">Settings</a>
-                  <a href="javascript:;" class="u-border-2 u-border-black u-border-hover-black u-btn u-btn-round u-button-style u-custom-color-2 u-hover-white u-radius-5 u-btn-2">Sim EP</a>
+                  <a href="javascript:;" onclick="statWeightLoop()"class="u-border-2 u-border-black u-border-hover-black u-btn u-btn-round u-button-style u-custom-color-2 u-hover-white u-radius-5 u-btn-2">Sim EP<div class="weightloadbar" id="weightloadbar"></div></a>
                   <a href="javascript:;" onclick="startSync()" id="simdps" class="u-border-2 u-border-black u-border-hover-black u-btn u-btn-round u-button-style u-custom-color-2 u-hover-white u-radius-5 u-btn-3">Sim DPS<div class="loadbar" id="loadbar"></div></a>
                   <a href="javascript:;" onclick="combatLogDisplay()" onmouseover="combatLogDisplay()" id="logbtn" class="u-border-2 u-border-black u-border-hover-black u-btn u-btn-round u-button-style u-custom-color-2 u-hover-white u-radius-5 u-btn-6">Combat Log</a>
                   <div class="dps-result">
@@ -219,6 +219,7 @@
                         <div class="gear-slot-details">
                           <p class="u-text item-name"><a href="#" id="headslot" onmouseover="gearSlotsDisplay()" onclick="this.href='javascript:;';">Head</a></p>
                           <p class="u-text enchant-name"><a id="headench" class="enchant-text" onmouseover="gearSlotsDisplay()" onclick="this.href='javascript:;';">No Enchant</a></p>
+                          <p class="u-text meta-req-fail" id="metareq">Meta: 2 Red, 2 Blue, 2 Yellow</p>
                         </div>
                       </div>
                       <div class="gear-slot">
@@ -944,26 +945,6 @@
         <option value="1">Phase 1</option>
       </select>
     </div>
-    <!--<div>
-      <div id="itemseldiv"><label class="label-2">Item:</label>
-      <select id="itemselect" onchange="selectItem(this.value)" class="select hover-grey gear-select-input">
-      </select></div>
-      <div id="gem1seldiv"><label id="labelgem1" class="label-2">Gem 1:</label>
-      <select id="gem1select" onchange="selectFirstGem(this.value)" class="select hover-grey gear-select-input">
-      </select></div>
-      <div id="gem2seldiv"><label id="labelgem2" class="label-2">Gem 2:</label>
-      <select id="gem2select" onchange="selectSecondGem(this.value)" class="select hover-grey gear-select-input">
-      </select></div>
-      <div id="gem3seldiv"><label id="labelgem3" class="label-2">Gem 3:</label>
-      <select id="gem3select" onchange="selectThirdGem(this.value)" class="select hover-grey gear-select-input">
-      </select></div>
-      <div id="enchseldiv"><label class="label-2">Enchant:</label>
-      <select id="enchselect" onchange="selectEnchant(this.value)" class="select hover-grey gear-select-input">
-      </select></div>
-      <div id="attachseldiv"><label class="label-2">Attachment:</label>
-        <select id="attachselect" onchange="selectAttachment(this.value)" class="select hover-grey gear-select-input">
-      </select></div>
-    </div><-->
     <ul class="item-selector">
       <li><button class="item-selector-tab" onclick="changeGearTab(event,'gearitem')" id="dftTab">
         <img class="gear-img-selector" id="selectoritem" src="" data-image-width="24" data-image-height="24"></button></li>
@@ -980,6 +961,7 @@
         <img class="gear-img-selector" id="selectorenchant" src="" data-image-width="24" data-image-height="24"></button></li>
       <li><button class="item-selector-tab" onclick="changeGearTab(event,'gearattach')" >
         <img class="gear-img-selector" id="selectorattachment" src="" data-image-width="24" data-image-height="24"></button></li>
+      <li><label class="sktrecommend"></label></li>
     </ul>
     <div id="filterweps">
       <label class="container container-3 filterchecks-1">2H<input type="checkbox" id="2hfilter" onchange=updateGearLists()><span class="checkmark"></span></label>
@@ -1113,7 +1095,9 @@
 
       <textarea id="importdata" name="import" rows="4" cols="50"></textarea>
       <br>
-      <button onclick="submitImportData()">Submit!</button>
+      <button onclick="submitImportData('70U')">Submit 70U!</button>
+      <button onclick="submitImportData('WA')">Submit WA Data!</button>
+      <button onclick="importSavedDataStorage()">Submit Exported Data!</button>
 
       <p id="confirmimport" class="label-2"></p>
     </div>

--- a/index.html
+++ b/index.html
@@ -73,8 +73,8 @@
           </div>
           <div class="u-custom-menu u-nav-container">
             <ul class="u-custom-font u-nav u-text-font u-unstyled u-nav-1"><li class="u-nav-item"><a class="u-button-style u-custom-color-2 u-nav-link u-text-active-custom-color-3 u-text-hover-custom-color-5" href="index.html" style="padding: 10px 20px;">Main</a>
-</li><li class="u-nav-item"><a class="u-button-style u-custom-color-2 u-nav-link u-text-active-custom-color-3 u-text-hover-custom-color-5" href="gearplanner/index.html" style="padding: 10px 20px;">Gear Planner</a>
-</li><li class="u-nav-item"><a class="u-button-style u-custom-color-2 u-nav-link u-text-active-custom-color-3 u-text-hover-custom-color-5" href="groupeval/index.html" style="padding: 10px 20px;">Group Evaluation</a>
+</li><li class="u-nav-item"><a class="u-button-style u-custom-color-2 u-nav-link u-text-active-custom-color-3 u-text-hover-custom-color-5" href="" style="padding: 10px 20px;">Gear Planner</a>
+</li><li class="u-nav-item"><a class="u-button-style u-custom-color-2 u-nav-link u-text-active-custom-color-3 u-text-hover-custom-color-5" href="" style="padding: 10px 20px;">Group Evaluation</a>
 </li></ul>
           </div>
           <div class="u-custom-menu u-nav-container-collapse">
@@ -82,8 +82,8 @@
               <div class="u-inner-container-layout u-sidenav-overflow">
                 <div class="u-menu-close"></div>
                 <ul class="u-align-center u-nav u-popupmenu-items u-unstyled u-nav-2"><li class="u-nav-item"><a class="u-button-style u-nav-link" href="index.html" style="padding: 10px 20px;">Main</a>
-</li><li class="u-nav-item"><a class="u-button-style u-nav-link" href="gearplanner/index.html" style="padding: 10px 20px;">Gear Planner</a>
-</li><li class="u-nav-item"><a class="u-button-style u-nav-link" href="groupeval/index.html" style="padding: 10px 20px;">Group Evaluation</a>
+</li><li class="u-nav-item"><a class="u-button-style u-nav-link" href="" style="padding: 10px 20px;">Gear Planner</a>
+</li><li class="u-nav-item"><a class="u-button-style u-nav-link" href="" style="padding: 10px 20px;">Group Evaluation</a>
 </li></ul>
               </div>
             </div>
@@ -219,7 +219,7 @@
                         <div class="gear-slot-details">
                           <p class="u-text item-name"><a href="#" id="headslot" onmouseover="gearSlotsDisplay()" onclick="this.href='javascript:;';">Head</a></p>
                           <p class="u-text enchant-name"><a id="headench" class="enchant-text" onmouseover="gearSlotsDisplay()" onclick="this.href='javascript:;';">No Enchant</a></p>
-                          <p class="u-text meta-req-fail" id="metareq">Meta: 2 Red, 2 Blue, 2 Yellow</p>
+                          <p class="u-text meta-req-fail" id="metareq"></p>
                         </div>
                       </div>
                       <div class="gear-slot">
@@ -493,82 +493,116 @@
     <div class="settings">
     <label class="settings-header-1">Party Buffs</label>
     <ul>
-        <img class="settings-image-1" src="https://wow.zamimg.com/images/wow/icons/large/spell_magic_greaterblessingofkings.jpg" alt="">
-      <li><label class="container container-1">Blessing of Kings<input type="checkbox" id="kings" onclick="kingsCheck()"><span class="checkmark"></span></label></li>
-        <img class="settings-image-2" src="https://wow.zamimg.com/images/wow/icons/large/spell_holy_greaterblessingofkings.jpg" alt="">
-      <li><label class="container container-2">Blessing of Might<input type="checkbox" id="might" onclick="mightCheck()"><span class="checkmark"></span>
-      <select onchange="mightCheck()" class="select hover-grey select-1">
-        <option value="improved" id="mightmod">Improved</option>
-        <option selected value="base">Base</option>
-      </select></label></li>
-        <img class="settings-image-3" src="https://wow.zamimg.com/images/wow/icons/large/spell_holy_greaterblessingofwisdom.jpg" alt="">
-      <li><label class="container container-2">Blessing of Wisdom<input type="checkbox" id="wisdom" onclick="wisdomCheck()"><span class="checkmark"></span>
-      <select onchange="wisdomCheck()" class="select hover-grey select-2">
-        <option value="improved" id="wisdommod">Improved</option>
-        <option selected value="base">Base</option>
-      </select></label></li>
-        <img class="settings-image-4" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_unyeildingstamina.jpg" alt="">
-      <li><label class="container container-2">Leader of the Pack<input type="checkbox" id="lotp" onclick="lotpCheck()"><span class="checkmark"></span>
-      <select onchange="lotpCheck()" class="select hover-grey select-10">
-        <option value="idol" id="lotpidol">Crit Idol</option>
-        <option selected value="none">None</option>
-      </select></label></li>
-        <img class="settings-image-5" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_invisibilitytotem.jpg" alt="">
-      <li><label class="container container-2">Grace of Air Totem<input type="checkbox" id="goa" onclick="totemCheck()"><span class="checkmark"></span></label></li>
-        <img class="settings-image-6" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_earthbindtotem.jpg" alt="">
-      <li><label class="container container-2">Strength of Earth Totem<input type="checkbox" id="soe" onclick="totemCheck()"><span class="checkmark"></span></label></li>
-      <select onchange="totemCheck()" class="select hover-grey select-3">
-        <option value="improved" id="imptotem">Improved</option>
-        <option selected value="base">Base</option>
-      </select>
-        <img class="settings-image-7" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_manaregentotem.jpg" alt="">
-      <li><label class="container container-1">Mana Spring Totem<input type="checkbox" id="manaspring" onclick="manaspringCheck()"><span class="checkmark"></span></label></li>
-        <img class="settings-image-8" src="https://wow.zamimg.com/images/wow/icons/large/spell_holy_arcaneintellect.jpg" alt="">
-      <li><label class="container container-1">Arcane Brilliance<input type="checkbox" id="ai" onclick="aiCheck()"><span class="checkmark"></span></label></li>
-        <img class="settings-image-9" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_giftofthewild.jpg" alt="">
-      <li><label class="container container-2">Gift of the Wild<input type="checkbox" id="gotw" onclick="gotwCheck()"><span class="checkmark"></span>
-        <select onchange="gotwCheck()" class="select hover-grey select-4">
-          <option value="improved" id="gotwmod">Improved</option>
+      <div class="relative-wrapper">
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/spell_magic_greaterblessingofkings.jpg" alt="">
+        <li><label class="container container-1">Blessing of Kings<input type="checkbox" id="kings" onclick="kingsCheck()"><span class="checkmark"></span></label></li>
+      </div>
+      <div class="relative-wrapper">
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/spell_holy_greaterblessingofkings.jpg" alt="">
+        <li><label class="container container-2">Blessing of Might<input type="checkbox" id="might" onclick="mightCheck()"><span class="checkmark"></span>
+        <select onchange="mightCheck()" class="select hover-grey select-1">
+          <option value="improved" id="mightmod">Improved</option>
           <option selected value="base">Base</option>
         </select></label></li>
-        <img class="settings-image-10" src="https://wow.zamimg.com/images/wow/icons/large/spell_holy_prayeroffortitude.jpg" alt="">
-      <li><label class="container container-2">Prayer of Fortitude<input type="checkbox" id="fort" onclick="fortCheck()"><span class="checkmark"></span>
-        <select onchange="fortCheck()" class="select hover-grey select-5">
-          <option value="improved" id="fortmod">Improved</option>
+      </div>
+      <div class="relative-wrapper">
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/spell_holy_greaterblessingofwisdom.jpg" alt="">
+        <li><label class="container container-2">Blessing of Wisdom<input type="checkbox" id="wisdom" onclick="wisdomCheck()"><span class="checkmark"></span>
+        <select onchange="wisdomCheck()" class="select hover-grey select-2">
+          <option value="improved" id="wisdommod">Improved</option>
           <option selected value="base">Base</option>
         </select></label></li>
-        <img class="settings-image-11" src="https://wow.zamimg.com/images/wow/icons/large/spell_shadow_bloodboil.jpg" alt="">
-      <li><label class="container container-2">Blood Pact<input type="checkbox" id="pact" onclick="pactCheck()"><span class="checkmark"></span>
-        <select onchange="pactCheck()" class="select hover-grey select-6">
-          <option value="improved" id="pactmod">Improved</option>
-          <option selected value="base">Base</option>
+      </div>
+      <div class="relative-wrapper">
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_unyeildingstamina.jpg" alt="">
+        <li><label class="container container-2">Leader of the Pack<input type="checkbox" id="lotp" onclick="lotpCheck()"><span class="checkmark"></span>
+        <select onchange="lotpCheck()" class="select hover-grey select-10">
+          <option value="idol" id="lotpidol">Crit Idol</option>
+          <option selected value="none">None</option>
         </select></label></li>
-        <img class="settings-image-12" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_windfury.jpg" alt="">
-      <li><label class="container container-2">Windfury Totem<input type="checkbox" id="windfury" onclick="windfuryCheck()"><span class="checkmark"></span>
-        <select onchange="windfuryCheck()" class="select hover-grey select-7">
-          <option value="improved" id="windfurymod">Improved</option>
-          <option selected value="base">Base</option>
-        </select></label></li>
-        <img class="settings-image-13" src="https://wow.zamimg.com/images/wow/icons/large/inv_helmet_21.jpg" alt="">
-      <li><label class="container container-1">Heroic Presence (not you)<input type="checkbox" id="heroicpres" onclick="heroicpresCheck()"><span class="checkmark"></span></label></li>
-        <img class="settings-image-14" src="https://wow.zamimg.com/images/wow/icons/large/ability_warrior_battleshout.jpg" alt="">
-      <li><label class="container container-2">Battle Shout<input type="checkbox" id="shout" onclick="shoutCheck()"><span class="checkmark"></span>
-        <select onchange="shoutCheck()" class="select hover-grey select-8">
-          <option value="improved" id="shoutmod">Improved</option>
+      </div>
+      <div class="relative-wrapper">
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_invisibilitytotem.jpg" alt="">
+        <li><label class="container container-2">Grace of Air Totem<input type="checkbox" id="goa" onclick="totemCheck()"><span class="checkmark"></span></label></li>
+      </div>
+      <div class="relative-wrapper">
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_earthbindtotem.jpg" alt="">
+        <li><label class="container container-2">Strength of Earth Totem<input type="checkbox" id="soe" onclick="totemCheck()"><span class="checkmark"></span></label></li>
+        <select onchange="totemCheck()" class="select hover-grey select-3">
+          <option value="improved" id="imptotem">Improved</option>
           <option selected value="base">Base</option>
         </select>
-        <select onchange="shoutCheck()" class="select hover-grey select-wide">
-          <option value="t2solarian">T2 3pc+Solarian</option>
-          <option value="t2">T2 3pc</option>
-          <option value="solarian">Solarian</option>
-          <option selected value="base">No Bonus</option>
-        </select></label></li>
-        <img class="settings-image-15" src="https://wow.zamimg.com/images/wow/icons/large/ability_trueshot.jpg" alt="">
-      <li><label class="container container-1">Trueshot Aura (not you)<input type="checkbox" id="tsa" onclick="tsaCheck()"><span class="checkmark"></span></label></li>
-        <img class="settings-image-16" src="https://wow.zamimg.com/images/wow/icons/large/inv_jewelry_necklace_07.jpg" alt="">
-      <li><label class="container container-2">Braided Eternium Chain (not you)<input type="checkbox" id="braided" onclick="braidedCheck()"><span class="checkmark"></span></label></li>
-        <img class="settings-image-17" src="https://wow.zamimg.com/images/wow/icons/large/spell_holy_mindvision.jpg" alt="">
-      <li><label class="container container-1">Improved Sanctity Aura<input type="checkbox" id="sanct" onclick="sanctCheck()"><span class="checkmark"></span></label></li>
+      </div>
+      <div class="relative-wrapper">
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_manaregentotem.jpg" alt="">
+        <li><label class="container container-1">Mana Spring Totem<input type="checkbox" id="manaspring" onclick="manaspringCheck()"><span class="checkmark"></span></label></li>
+      </div>
+      <div class="relative-wrapper">
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/spell_holy_arcaneintellect.jpg" alt="">
+        <li><label class="container container-1">Arcane Brilliance<input type="checkbox" id="ai" onclick="aiCheck()"><span class="checkmark"></span></label></li>
+      </div>
+      <div class="relative-wrapper">
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_giftofthewild.jpg" alt="">
+        <li><label class="container container-2">Gift of the Wild<input type="checkbox" id="gotw" onclick="gotwCheck()"><span class="checkmark"></span>
+          <select onchange="gotwCheck()" class="select hover-grey select-4">
+            <option value="improved" id="gotwmod">Improved</option>
+            <option selected value="base">Base</option>
+          </select></label></li>
+      </div>
+      <div class="relative-wrapper">
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/spell_holy_prayeroffortitude.jpg" alt="">
+        <li><label class="container container-2">Prayer of Fortitude<input type="checkbox" id="fort" onclick="fortCheck()"><span class="checkmark"></span>
+          <select onchange="fortCheck()" class="select hover-grey select-5">
+            <option value="improved" id="fortmod">Improved</option>
+            <option selected value="base">Base</option>
+          </select></label></li>
+      </div>
+      <div class="relative-wrapper">
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/spell_shadow_bloodboil.jpg" alt="">
+        <li><label class="container container-2">Blood Pact<input type="checkbox" id="pact" onclick="pactCheck()"><span class="checkmark"></span>
+          <select onchange="pactCheck()" class="select hover-grey select-6">
+            <option value="improved" id="pactmod">Improved</option>
+            <option selected value="base">Base</option>
+          </select></label></li>
+      </div>
+      <div class="relative-wrapper">
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_windfury.jpg" alt="">
+        <li><label class="container container-2">Windfury Totem<input type="checkbox" id="windfury" onclick="windfuryCheck()"><span class="checkmark"></span>
+          <select onchange="windfuryCheck()" class="select hover-grey select-7">
+            <option value="improved" id="windfurymod">Improved</option>
+            <option selected value="base">Base</option>
+          </select></label></li>
+      </div>
+      <div class="relative-wrapper">
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/inv_helmet_21.jpg" alt="">
+        <li><label class="container container-1">Heroic Presence (not you)<input type="checkbox" id="heroicpres" onclick="heroicpresCheck()"><span class="checkmark"></span></label></li>
+      </div>
+      <div class="relative-wrapper">  
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/ability_warrior_battleshout.jpg" alt="">
+        <li><label class="container container-2">Battle Shout<input type="checkbox" id="shout" onclick="shoutCheck()"><span class="checkmark"></span>
+          <select onchange="shoutCheck()" class="select hover-grey select-8">
+            <option value="improved" id="shoutmod">Improved</option>
+            <option selected value="base">Base</option>
+          </select>
+          <select onchange="shoutCheck()" class="select hover-grey select-wide">
+            <option value="t2solarian">T2 3pc+Solarian</option>
+            <option value="t2">T2 3pc</option>
+            <option value="solarian">Solarian</option>
+            <option selected value="base">No Bonus</option>
+          </select></label></li>
+      </div>
+      <div class="relative-wrapper">
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/ability_trueshot.jpg" alt="">
+        <li><label class="container container-1">Trueshot Aura (not you)<input type="checkbox" id="tsa" onclick="tsaCheck()"><span class="checkmark"></span></label></li>
+      </div>
+      <div class="relative-wrapper">
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/inv_jewelry_necklace_07.jpg" alt="">
+        <li><label class="container container-2">Braided Eternium Chain (not you)<input type="checkbox" id="braided" onclick="braidedCheck()"><span class="checkmark"></span></label></li>
+      </div>
+      <div class="relative-wrapper">
+        <img class="settings-image-buffs" src="https://wow.zamimg.com/images/wow/icons/large/spell_holy_mindvision.jpg" alt="">
+        <li><label class="container container-1">Improved Sanctity Aura<input type="checkbox" id="sanct" onclick="sanctCheck()"><span class="checkmark"></span></label></li>
+      </div>
     </ul>
 
     </div>
@@ -735,43 +769,53 @@
       </ul></div>
     </div>
     <div class="settings settings-small">
-      <label class="settings-header-1">Target Debuff Settings</label>
+      <label class="settings-header-1">Aura Uptime Settings</label>
       <div class="settings-fight">
         <ul>
-          <li><img class="settings-image-18" src="https://wow.zamimg.com/images/wow/icons/large/ability_hunter_snipershot.jpg" alt=""><label class="label-4">Hunter's Mark (Others)</label>
-            <input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="hmuptime" onchange=debuffSettings() value="100"> %</li>
-            <li><label class="label-5">HM - Bonus</label><select onchange=debuffSettings() class="select hover-grey select-9">
+          <li><img class="settings-image-auras" src="https://wow.zamimg.com/images/wow/icons/large/ability_hunter_snipershot.jpg" alt=""><label class="label-4">Hunter's Mark (Others)</label>
+            <input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="hmuptime" onchange=auraUptimeSettings() value="100"> %</li>
+            <li><label class="label-5">HM - Bonus</label><select onchange=auraUptimeSettings() class="select hover-grey select-imp-auras-2">
               <option id="hmbonus" value="improved">Improved</option>
               <option selected value="base">Base</option>
             </select>
-            <br>
-          <li><img class="settings-image-18" src="https://wow.zamimg.com/images/wow/icons/large/ability_rogue_findweakness.jpg" alt=""><label class="label-4">Expose Weakness (Others)</label>
-            <input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="ewuptime" onchange=debuffSettings() value="0"> %</li>
-          <li><label class="label-5">EW - Agility</label><input type="number" step="1" min="500" max="2000" class="number-input hover-grey debuff-setting-input-1" id="ewagil" onchange=debuffSettings() value="1000"></li>
-          <br>
-          <li><img class="settings-image-18" src="https://wow.zamimg.com/images/wow/icons/large/spell_holy_righteousnessaura.jpg" alt=""><label class="label-4">Judgement of Wisdom</label>
-            <input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="jowuptime" onchange=debuffSettings() value="90"> %</li>
-          <li><img class="settings-image-18" src="https://wow.zamimg.com/images/wow/icons/large/spell_holy_holysmite.jpg" alt=""><label class="label-4">Judgement of the Crusader</label>
-            <input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="jocuptime" onchange=debuffSettings() value="90"> %</li>
-          <li><img class="settings-image-18" src="https://wow.zamimg.com/images/wow/icons/large/spell_shadow_unholystrength.jpg" alt=""><label class="label-4">Curse of Recklessness</label>
-            <input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="coruptime" onchange=debuffSettings() value="95"> %</li>
-          <li><img class="settings-image-18" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_faeriefire.jpg" alt=""><label class="label-4">Faerie Fire</label>
-            <input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="ffuptime" onchange=debuffSettings() value="90"> %</li>
-          <li><label class="label-5">FF - Bonus</label><select onchange=debuffSettings() class="select hover-grey select-9">
-            <option id="ffbonus" value="improved">Improved</option>
-            <option selected value="base">Base</option>
+            
+          <li><img class="settings-image-auras" src="https://wow.zamimg.com/images/wow/icons/large/ability_rogue_findweakness.jpg" alt=""><label class="label-4">Expose Weakness (Others)</label>
+            <input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="ewuptime" onchange=auraUptimeSettings() value="0"> %</li>
+          <li><label class="label-5">EW - Agility</label><input type="number" step="1" min="500" max="2000" class="number-input hover-grey debuff-setting-input-1" id="ewagil" onchange=auraUptimeSettings() value="1000"></li>
+          <li><img class="settings-image-auras" src="https://wow.zamimg.com/images/wow/icons/large/spell_holy_righteousnessaura.jpg" alt=""><label class="label-4">Judgement of Wisdom</label>
+            <input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="jowuptime" onchange=auraUptimeSettings() value="90"> %</li>
+          <li><img class="settings-image-auras" src="https://wow.zamimg.com/images/wow/icons/large/spell_holy_holysmite.jpg" alt=""><label class="label-4">Judgement of the Crusader</label>
+            <input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="jocuptime" onchange=auraUptimeSettings() value="90"> %</li>
+          <li><img class="settings-image-auras" src="https://wow.zamimg.com/images/wow/icons/large/spell_shadow_unholystrength.jpg" alt=""><label class="label-4">Curse of Recklessness</label>
+            <input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="coruptime" onchange=auraUptimeSettings() value="95"> %</li>
+          <li><img class="settings-image-auras" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_faeriefire.jpg" alt=""><label class="label-4">Faerie Fire</label>
+            <input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="ffuptime" onchange=auraUptimeSettings() value="90"> %</li>
+          <div class="relative-wrapper">  
+            <select onchange=auraUptimeSettings() class="select hover-grey select-imp-auras">
+              <option id="ffbonus" value="improved">Improved</option>
+              <option selected value="base">Base</option>
+            </select>
+          </div>
+          <li><img class="settings-image-auras" src="https://wow.zamimg.com/images/wow/icons/large/ability_warrior_sunder.jpg" alt=""><label class="label-6">Sunder Armor</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="sauptime" onchange=auraUptimeSettings() value="0"> %</li>
+          <li><label class="label-8">SA - Stack time</label><input type="number" step="1" min="0" max="20" class="number-input hover-grey debuff-setting-input-1" id="sunderapp" onchange=auraUptimeSettings() value="5">sec</li>
+          <li><img class="settings-image-auras" src="https://wow.zamimg.com/images/wow/icons/large/ability_warrior_riposte.jpg" alt=""><label class="label-6">Improved Expose Armor</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="ieuptime" onchange=auraUptimeSettings() value="100"> %</li>
+          <li><img class="settings-image-auras" src="https://wow.zamimg.com/images/wow/icons/large/ability_warrior_bloodfrenzy.jpg" alt=""><label class="label-6">Blood Frenzy</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="bfuptime" onchange=auraUptimeSettings() value="100"> %</li>
+          <li><img class="settings-image-auras" src="https://wow.zamimg.com/images/wow/icons/large/spell_shadow_misery.jpg" alt=""><label class="label-6">Misery</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="misuptime" onchange=auraUptimeSettings() value="100"> %</li>
+          <li><img class="settings-image-auras" src="https://wow.zamimg.com/images/wow/icons/large/spell_shadow_chilltouch.jpg" alt=""><label class="label-6">Curse of Ele.</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="coeuptime" onchange=auraUptimeSettings() value="100"> %</li>
+          <div class="relative-wrapper">
+            <select onchange=auraUptimeSettings() class="select hover-grey select-imp-auras">
+              <option id="coebonus" value="improved">Improved</option>
+              <option selected value="base">Base</option>
+            </select>
+          </div>
+          <li><img class="settings-image-auras" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_unleashedrage.jpg" alt=""><label class="label-6">Unleashed Rage</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="unlrageuptime" onchange=auraUptimeSettings() value="100"> %</li>
+          <li><img class="settings-image-auras" src="https://wow.zamimg.com/images/wow/icons/large/ability_hunter_ferociousinspiration.jpg" alt=""><label class="label-6">Ferocious Insp. (Others)</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="ferocuptime" onchange=auraUptimeSettings() value="100"> %</li>
+          <li><label class="label-5"># of BMs</label><select id="ferocstacks" onchange=auraUptimeSettings() class="select hover-grey select-imp-auras-2">
+            <option value="4">4</option>
+            <option value="3">3</option>
+            <option value="2">2</option>
+            <option selected value="1">1</option>
           </select></li>
-          <li><img class="settings-image-18" src="https://wow.zamimg.com/images/wow/icons/large/ability_warrior_sunder.jpg" alt=""><label class="label-6">Sunder Armor</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="sauptime" onchange=debuffSettings() value="0"> %</li>
-          <li><label class="label-8">SA - Stack time</label><input type="number" step="1" min="0" max="20" class="number-input hover-grey debuff-setting-input-1" id="sunderapp" onchange=debuffSettings() value="5">sec</li>
-          <br>
-          <li><img class="settings-image-18" src="https://wow.zamimg.com/images/wow/icons/large/ability_warrior_riposte.jpg" alt=""><label class="label-6">Improved Expose Armor</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="ieuptime" onchange=debuffSettings() value="90"> %</li>
-          <li><img class="settings-image-18" src="https://wow.zamimg.com/images/wow/icons/large/ability_warrior_bloodfrenzy.jpg" alt=""><label class="label-6">Blood Frenzy</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="bfuptime" onchange=debuffSettings() value="95"> %</li>
-          <li><img class="settings-image-18" src="https://wow.zamimg.com/images/wow/icons/large/spell_shadow_misery.jpg" alt=""><label class="label-6">Misery</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="misuptime" onchange=debuffSettings() value="0"> %</li>
-          <li><img class="settings-image-18" src="https://wow.zamimg.com/images/wow/icons/large/spell_shadow_chilltouch.jpg" alt=""><label class="label-6">Curse of Elements</label><input type="number" step="1" min="0" max="100" class="number-input hover-grey debuff-setting-input-1" id="coeuptime" onchange=debuffSettings() value="0"> %</li>
-          <li><label class="label-5">CoE - Bonus</label><select onchange=debuffSettings() class="select hover-grey select-9">
-            <option id="coebonus" value="improved">Improved</option>
-            <option selected value="base">Base</option>
-          </select>
         </ul>
       </div>
     </div>
@@ -779,40 +823,53 @@
       <label class="settings-header-1">Spells/Buffs Options</label>
       <div class="settings-spells">
         <ul><label class="spell-option-2">Options</label><label class="spell-option-1">Offsets (s)</label>
-          <img class="spells-image spells-image-1" src="https://wow.zamimg.com/images/wow/icons/large/ability_hunter_runningshot.jpg" alt="">
-          <li><label class="container container-2">Rapid Fire<input id="rapidcheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
-          <input id="rapidoffset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input spells-input-1" value="0" onchange="spellOffsets()">
-          
-          <img class="spells-image spells-image-2" src="https://wow.zamimg.com/images/wow/icons/large/ability_druid_ferociousbite.jpg" alt="">
-          <li><label class="container container-2">Bestial Wrath<input id="beastcheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
-          <input id="beastoffset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input spells-input-2" value="0" onchange="spellOffsets()">
-          <img class="spells-image spells-image-3" src="https://wow.zamimg.com/images/wow/icons/large/racial_orc_berserkerstrength.jpg" alt="">
-          <li><label class="container container-2">Racial<input id="racialcheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
-          <input id="racialoffset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input spells-input-3" value="0" onchange="spellOffsets()">
-          <img class="spells-image spells-image-4" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_bloodlust.jpg" alt="">
-          <li><label class="container container-2">Bloodlust<input id="lustcheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span>
-            <select id="lustoption" onchange="spellOptions()" class="select hover-grey select-spell-option-1">
-              <option value="4">4 Lusts</option>
-              <option value="3">3 Lusts</option>
-              <option value="2">2 Lusts</option>
-              <option selected value="1">1 Lust</option>
-            </select></label>
-          </li>
-          <input id="lustoffset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input spells-input-4" value="0" onchange="spellOffsets()">
-          <img class="spells-image spells-image-5" src="https://wow.zamimg.com/images/wow/icons/large/inv_misc_drum_02.jpg" alt="">
-          <li><label class="container container-2">Drums<input id="drumcheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span>
-            <select id="drumoption" onchange="spellOptions()" class="select hover-grey select-spell-option-2">
-              <option selected value="battle">Battle</option>
-              <option value="war">War</option>
-            </select></label>
-          </li>
-          <input id="drumoffset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input spells-input-5" value="0" onchange="spellOffsets()">
-          <img class="spells-image spells-image-6" src="https://wow.zamimg.com/images/wow/icons/large/inv_misc_monsterscales_15.jpg" alt="">
-          <li><label class="container container-2">Trinket 1 (On Use)</label></li>
-          <input id="trink1offset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input spells-input-6" value="0" onchange="spellOffsets()">
-          <img class="spells-image spells-image-7" src="https://wow.zamimg.com/images/wow/icons/large/inv_misc_bone_03.jpg" alt="">
-          <li><label class="container container-2">Trinket 2 (On Use)</label></li>
-          <input id="trink2offset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input spells-input-7" value="0" onchange="spellOffsets()">
+          <div class="relative-wrapper-spells">
+            <img class="spells-image" src="https://wow.zamimg.com/images/wow/icons/large/ability_hunter_runningshot.jpg" alt="">
+            <li><label class="container container-2 container-adjust-top">Rapid Fire<input id="rapidcheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
+            <input id="rapidoffset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input" value="0" onchange="spellOffsets()">
+          </div>
+          <div class="relative-wrapper-spells">
+            <img class="spells-image" src="https://wow.zamimg.com/images/wow/icons/large/ability_druid_ferociousbite.jpg" alt="">
+            <li><label class="container container-2 container-adjust-top">Bestial Wrath<input id="beastcheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
+            <input id="beastoffset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input" value="0" onchange="spellOffsets()">
+          </div>
+          <div class="relative-wrapper-spells">
+            <img class="spells-image" src="https://wow.zamimg.com/images/wow/icons/large/racial_orc_berserkerstrength.jpg" alt="">
+            <li><label class="container container-2 container-adjust-top">Racial<input id="racialcheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
+            <input id="racialoffset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input" value="0" onchange="spellOffsets()">
+          </div>
+          <div class="relative-wrapper-spells">
+            <img class="spells-image" src="https://wow.zamimg.com/images/wow/icons/large/spell_nature_bloodlust.jpg" alt="">
+            <li><label class="container container-2 container-adjust-top">Bloodlust<input id="lustcheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span>
+              <select id="lustoption" onchange="spellOptions()" class="select hover-grey select-spell-option-1">
+                <option value="4">4 Lusts</option>
+                <option value="3">3 Lusts</option>
+                <option value="2">2 Lusts</option>
+                <option selected value="1">1 Lust</option>
+              </select></label>
+            </li>
+            <input id="lustoffset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input" value="0" onchange="spellOffsets()">
+          </div>
+          <div class="relative-wrapper-spells">
+            <img class="spells-image" src="https://wow.zamimg.com/images/wow/icons/large/inv_misc_drum_02.jpg" alt="">
+            <li><label class="container container-2 container-adjust-top">Drums<input id="drumcheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span>
+              <select id="drumoption" onchange="spellOptions()" class="select hover-grey select-spell-option-2">
+                <option selected value="battle">Battle</option>
+                <option value="war">War</option>
+              </select></label>
+            </li>
+            <input id="drumoffset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input" value="0" onchange="spellOffsets()">
+          </div>
+          <div class="relative-wrapper-spells">
+            <img class="spells-image" src="https://wow.zamimg.com/images/wow/icons/large/inv_misc_monsterscales_15.jpg" alt="">
+            <li><label class="container container-2 container-adjust-top">Trinket 1 (On Use)</label></li>
+            <input id="trink1offset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input" value="0" onchange="spellOffsets()">
+          </div>
+          <div class="relative-wrapper-spells">
+            <img class="spells-image" src="https://wow.zamimg.com/images/wow/icons/large/inv_misc_bone_03.jpg" alt="">
+            <li><label class="container container-2 container-adjust-top">Trinket 2 (On Use)</label></li>
+            <input id="trink2offset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input" value="0" onchange="spellOffsets()">
+          </div>
           <li><label class="label-2 spell-label-1">Spell CD Behavior:</label>
             <select id="spellcdoption" onchange="spellOptions()" class="select hover-grey select-spell-option-5">
               <option selected value="CD">On CD</option>
@@ -820,28 +877,42 @@
               <option value="2min">2 min w/ 3 min</option>
             </select>
           </li>
-          <img class="spells-image spells-image-8" src="https://wow.zamimg.com/images/wow/icons/large/inv_potion_108.jpg" alt="">
-          <li><label class="container container-2">Primary Potion (Haste)<input id="hastecheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
-          <input id="startpotoffset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input spells-input-8" value="0" onchange="spellOffsets()">
-          <img class="spells-image spells-image-9" src="https://wow.zamimg.com/images/wow/icons/large/inv_potion_137.jpg" alt="">
-          <li><label class="container container-2">Secondary Potion<input id="secpotcheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span>
-            <select id="secpotoption" onchange="spellOptions()" class="select hover-grey select-spell-option-4">
-              <option value="Fel">Fel</option>
-              <option selected value="Super">Super</option>
-            </select></label>
-          </li>
-          <img class="spells-image spells-image-10" src="https://wow.zamimg.com/images/wow/icons/large/spell_shadow_sealofkings.jpg" alt="">
-          <li><label class="container container-2">Runes<input id="runecheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
-          <!--<input id="runeoffset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input spells-input-9" value="0" onchange="spellOffsets()">-->
+
+          <div class="relative-wrapper-spells">
+            <img class="spells-image" src="https://wow.zamimg.com/images/wow/icons/large/inv_potion_108.jpg" alt="">
+            <li><label class="container container-2 container-adjust-top">Primary Potion (Haste)<input id="hastecheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
+            <input id="startpotoffset" type="number" step="1" min="0" max="500" class="number-input hover-grey spells-input" value="0" onchange="spellOffsets()">
+          </div>
+          <div class="relative-wrapper-spells">
+            <img class="spells-image" src="https://wow.zamimg.com/images/wow/icons/large/inv_potion_137.jpg" alt="">
+            <li><label class="container container-2 container-adjust-top">Secondary Potion<input id="secpotcheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span>
+              <select id="secpotoption" onchange="spellOptions()" class="select hover-grey select-spell-option-4">
+                <option value="Fel">Fel</option>
+                <option selected value="Super">Super</option>
+              </select></label>
+            </li>
+          </div>
+          <div class="relative-wrapper-spells">
+            <img class="spells-image" src="https://wow.zamimg.com/images/wow/icons/large/spell_shadow_sealofkings.jpg" alt="">
+            <li><label class="container container-2 container-adjust-top">Runes<input id="runecheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
+          </div>
           <br>
-          <img class="spells-image spells-image-11" src="https://wow.zamimg.com/images/wow/icons/large/ability_upgrademoonglaive.jpg" alt="">
-          <li><label class="container container-1">Multi-Shot<input id="multicheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
-          <img class="spells-image spells-image-12" src="https://wow.zamimg.com/images/wow/icons/large/ability_impalingbolt.jpg" alt="">
-          <li><label class="container container-1">Arcane Shot<input id="arcanecheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
-          <img class="spells-image spells-image-13" src="https://wow.zamimg.com/images/wow/icons/large/ability_meleedamage.jpg" alt="">
-          <li><label class="container container-1">Raptor Strike<input id="raptorcheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
-          <img class="spells-image spells-image-14" src="https://wow.zamimg.com/images/wow/icons/large/inv_sword_04.jpg" alt="">
-          <li><label class="container container-1">Melee Attack<input id="meleecheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
+          <div class="relative-wrapper-spells">
+            <img class="spells-image" src="https://wow.zamimg.com/images/wow/icons/large/ability_upgrademoonglaive.jpg" alt="">
+            <li><label class="container container-1 container-adjust-top">Multi-Shot<input id="multicheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
+          </div>
+          <div class="relative-wrapper-spells">  
+            <img class="spells-image" src="https://wow.zamimg.com/images/wow/icons/large/ability_impalingbolt.jpg" alt="">
+            <li><label class="container container-1 container-adjust-top">Arcane Shot<input id="arcanecheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
+          </div>  
+          <div class="relative-wrapper-spells">  
+            <img class="spells-image" src="https://wow.zamimg.com/images/wow/icons/large/ability_meleedamage.jpg" alt="">
+            <li><label class="container container-1 container-adjust-top">Raptor Strike<input id="raptorcheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
+          </div>  
+          <div class="relative-wrapper-spells">
+            <img class="spells-image" src="https://wow.zamimg.com/images/wow/icons/large/inv_sword_04.jpg" alt="">
+            <li><label class="container container-1 container-adjust-top">Melee Attack<input id="meleecheck" type="checkbox" onclick="spellEnableCheck()"><span class="checkmark"></span></label></li>
+          </div>
         </ul>
       </div>
     </div>
@@ -962,6 +1033,9 @@
       <li><button class="item-selector-tab" onclick="changeGearTab(event,'gearattach')" >
         <img class="gear-img-selector" id="selectorattachment" src="" data-image-width="24" data-image-height="24"></button></li>
       <li><label class="sktrecommend"></label></li>
+      <div>
+        <p class="label-9">DPS Values are just estimates. Run the sims for actual accurate DPS results.</p>
+      </div>
     </ul>
     <div id="filterweps">
       <label class="container container-3 filterchecks-1">2H<input type="checkbox" id="2hfilter" onchange=updateGearLists()><span class="checkmark"></span></label>

--- a/js/data/gear.js
+++ b/js/data/gear.js
@@ -8649,6 +8649,51 @@ const MELEE_WEAPONS = {
         icon: "inv_weapon_hand_16",
         quality: "Epic"
     },
+    34247: {
+        name: "Apolyon, the Soul-Render",
+        stats: {
+            Stam: 75,
+            Crit: 42,
+            Haste: 32,
+            MAP: 126,
+            RAP: 126
+        },
+        Location: "Sunwell",
+        sockets: [
+            "Red",
+            "Red",
+            "Red"
+        ],
+        socketBonus: {
+            Stam: 6
+        },
+        type: "sword",
+        speed: 3.4,
+        mindmg: 404,
+        maxdmg: 607,
+        hand: "Two",
+        Phase: 5,
+        icon: "inv_sword_116",
+        quality: "Epic"
+    },
+    34198: {
+        name: "Stanchion of Primal Instinct",
+        stats: {
+            Agi: 75,
+            Str: 47,
+            Stam: 50,
+            ArP: 350
+        },
+        Location: "Sunwell",
+        type: "staff",
+        speed: 3.0,
+        mindmg: 137,
+        maxdmg: 306,
+        hand: "Two",
+        Phase: 5,
+        icon: "inv_staff_12",
+        quality: "Epic"
+    },
     34952: {
         name: "The Mutilator",
         stats: {
@@ -9264,20 +9309,6 @@ const QUIVERS = {
 }
 
 const RANGED_WEAPONS = {
-    12651: {
-        name: "Blackcrow",
-        stats: {
-            Agi: 3,
-            Hit: 10
-        },
-        type: "Xbow",
-        mindmg: 99,
-        maxdmg: 149,
-        speed: 3.2,
-        Phase: 1,
-        icon: "inv_weapon_crossbow_04",
-        quality: "Rare"
-    },
     15808: {
         name: "Fine Light Crossbow",
         type: "Xbow",
@@ -9286,62 +9317,8 @@ const RANGED_WEAPONS = {
         speed: 2.7,
         Phase: 1,
         icon: "inv_weapon_crossbow_02",
-        quality: "Common"
-    },
-    17072: {
-        name: "Blastershot Launcher",
-        stats: {
-            Stam: 6,
-            Crit: 14
-        },
-        type: "Gun",
-        mindmg: 89,
-        maxdmg: 167,
-        speed: 2.6,
-        Phase: 1,
-        icon: "inv_weapon_rifle_09",
-        quality: "Epic"
-    },
-    18713: {
-        name: "Rhok'delar, Longbow of the Ancient Keepers",
-        stats: {
-            RAP: 17,
-            Crit: 14
-        },
-        type: "Bow",
-        mindmg: 108,
-        maxdmg: 201,
-        speed: 2.9,
-        Phase: 1,
-        icon: "inv_weapon_bow_01",
-        quality: "Epic"
-    },
-    18729: {
-        name: "Screeching Bow",
-        stats: {
-            Stam: 3
-        },
-        type: "Bow",
-        mindmg: 90,
-        maxdmg: 90,
-        speed: 2.3,
-        Phase: 1,
-        icon: "inv_weapon_bow_12",
-        quality: "Rare"
-    },
-    19350: {
-        name: "Heartstriker",
-        stats: {
-            MAP: 24,
-            RAP: 24
-        },
-        type: "Bow",
-        mindmg: 97,
-        maxdmg: 180,
-        speed: 2.6,
-        Phase: 1,
-        icon: "inv_weapon_bow_09",
-        quality: "Epic"
+        quality: "Common",
+        Location: "Vendor"
     },
     19361: {
         name: "Ashjre'thul, Crossbow of Smiting",
@@ -9355,81 +9332,8 @@ const RANGED_WEAPONS = {
         speed: 3.4,
         Phase: 1,
         icon: "inv_weapon_crossbow_09",
-        quality: "Epic"
-    },
-    20437: {
-        name: "Outrider's Bow",
-        stats: {
-            Agi: 4,
-            Stam: 10
-        },
-        type: "Bow",
-        mindmg: 68,
-        maxdmg: 128,
-        speed: 2.4,
-        Phase: 1,
-        icon: "inv_weapon_bow_06",
-        quality: "Rare"
-    },
-    20599: {
-        name: "Polished Ironwood Crossbow",
-        stats: {
-            Stam: 5,
-            MAP: 24,
-            RAP: 24
-        },
-        type: "Xbow",
-        mindmg: 124,
-        maxdmg: 186,
-        speed: 3.1,
-        Phase: 1,
-        icon: "inv_weapon_crossbow_11",
-        quality: "Epic"
-    },
-    21272: {
-        name: "Blessed Qiraji Musket",
-        stats: {
-            Stam: 10,
-            RAP: 31
-        },
-        type: "Gun",
-        mindmg: 103,
-        maxdmg: 192,
-        speed: 2.6,
-        Phase: 1,
-        icon: "inv_weapon_rifle_11",
-        quality: "Epic"
-    },
-    21459: {
-        name: "Crossbow of Imminent Doom",
-        stats: {
-            Str: 5,
-            Agi: 7,
-            Stam: 5,
-            Hit: 10
-        },
-        type: "Xbow",
-        mindmg: 126,
-        maxdmg: 189,
-        speed: 3.1,
-        Phase: 1,
-        icon: "inv_weapon_crossbow_06",
-        quality: "Epic"
-    },
-    22318: {
-        name: "Malgen's Long Bow",
-        stats: {
-            Stam: 4,
-            MAP: 20,
-            RAP: 20
-        },
-        type: "Bow",
-        mindmg: 80,
-        maxdmg: 150,
-        speed: 2.9,
-        Phase: 1,
-        icon: "inv_weapon_bow_12",
-        quality: "Rare"
+        quality: "Epic",
+        Location: "BWL"
     },
     22812: {
         name: "Nerubian Slavemaker",
@@ -9444,7 +9348,8 @@ const RANGED_WEAPONS = {
         speed: 3.2,
         Phase: 1,
         icon: "inv_weapon_crossbow_12",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Naxx"
     },
     23746: {
         name: "Adamantite Rifle",
@@ -9459,7 +9364,8 @@ const RANGED_WEAPONS = {
         speed: 3,
         Phase: 1,
         icon: "inv_weapon_rifle_04",
-        quality: "Uncommon"
+        quality: "Uncommon",
+        Location: "Crafted"
     },
     23747: {
         name: "Felsteel Boomstick",
@@ -9473,7 +9379,8 @@ const RANGED_WEAPONS = {
         speed: 2.4,
         Phase: 1,
         icon: "inv_weapon_rifle_04",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Crafted"
     },
     23748: {
         name: "Ornate Khorium Rifle",
@@ -9487,7 +9394,8 @@ const RANGED_WEAPONS = {
         speed: 3.1,
         Phase: 1,
         icon: "inv_weapon_rifle_03",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Crafted"
     },
     24381: {
         name: "Coilfang Needler",
@@ -9502,7 +9410,8 @@ const RANGED_WEAPONS = {
         speed: 2.9,
         Phase: 1,
         icon: "inv_weapon_crossbow_11",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Dungeon"
     },
     25248: {
         name: "Talbuk Hunting Bow",
@@ -9512,7 +9421,8 @@ const RANGED_WEAPONS = {
         speed: 2.7,
         Phase: 1,
         icon: "inv_weapon_bow_16",
-        quality: "Uncommon"
+        quality: "Uncommon",
+        Location: "World Drop"
     },
     25249: {
         name: "Ranger's Recurved Bow",
@@ -9522,7 +9432,8 @@ const RANGED_WEAPONS = {
         speed: 2.7,
         Phase: 1,
         icon: "inv_weapon_bow_05",
-        quality: "Uncommon"
+        quality: "Uncommon",
+        Location: "World Drop"
     },
     25260: {
         name: "Archer's Crossbow",
@@ -9532,7 +9443,8 @@ const RANGED_WEAPONS = {
         speed: 2.7,
         Phase: 1,
         icon: "inv_weapon_crossbow_02",
-        quality: "Uncommon"
+        quality: "Uncommon",
+        Location: "World Drop"
     },
     25262: {
         name: "Battle Damaged Crossbow",
@@ -9542,7 +9454,8 @@ const RANGED_WEAPONS = {
         speed: 2.7,
         Phase: 1,
         icon: "inv_weapon_crossbow_02",
-        quality: "Uncommon"
+        quality: "Uncommon",
+        Location: "World Drop"
     },
     25263: {
         name: "Assassins' Silent Crossbow",
@@ -9552,7 +9465,8 @@ const RANGED_WEAPONS = {
         speed: 2.7,
         Phase: 1,
         icon: "inv_weapon_crossbow_02",
-        quality: "Uncommon"
+        quality: "Uncommon",
+        Location: "World Drop"
     },
     25267: {
         name: "Rampant Crossbow",
@@ -9562,7 +9476,8 @@ const RANGED_WEAPONS = {
         speed: 2.7,
         Phase: 1,
         icon: "inv_weapon_crossbow_02",
-        quality: "Uncommon"
+        quality: "Uncommon",
+        Location: "World Drop"
     },
     25278: {
         name: "Nessingwary Longrifle",
@@ -9572,7 +9487,8 @@ const RANGED_WEAPONS = {
         speed: 2.7,
         Phase: 1,
         icon: "inv_weapon_rifle_03",
-        quality: "Uncommon"
+        quality: "Uncommon",
+        Location: "World Drop"
     },
     25639: {
         name: "Hemet's Elekk Gun",
@@ -9587,7 +9503,8 @@ const RANGED_WEAPONS = {
         speed: 2.5,
         Phase: 1,
         icon: "inv_weapon_rifle_05",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Quest Reward"
     },
     25953: {
         name: "Ethereal Warp-Bow",
@@ -9601,7 +9518,8 @@ const RANGED_WEAPONS = {
         speed: 2.7,
         Phase: 1,
         icon: "inv_weapon_bow_20",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Dungeon"
     },
     27507: {
         name: "Adamantine Repeater",
@@ -9615,7 +9533,8 @@ const RANGED_WEAPONS = {
         speed: 3,
         Phase: 1,
         icon: "inv_weapon_crossbow_15",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Dungeon"
     },
     27526: {
         name: "Skyfire Hawk-Bow",
@@ -9630,7 +9549,8 @@ const RANGED_WEAPONS = {
         speed: 2.4,
         Phase: 1,
         icon: "inv_weapon_bow_17",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Dungeon"
     },
     27794: {
         name: "Recoilless Rocket Ripper X-54",
@@ -9644,7 +9564,8 @@ const RANGED_WEAPONS = {
         speed: 2.9,
         Phase: 1,
         icon: "inv_weapon_rifle_19",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Dungeon"
     },
     27817: {
         name: "Starbolt Longbow",
@@ -9658,7 +9579,8 @@ const RANGED_WEAPONS = {
         speed: 2.8,
         Phase: 1,
         icon: "inv_weapon_bow_06",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Dungeon"
     },
     27898: {
         name: "Wrathfire Hand-Cannon",
@@ -9673,7 +9595,8 @@ const RANGED_WEAPONS = {
         speed: 2,
         Phase: 1,
         icon: "inv_weapon_rifle_20",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Dungeon"
     },
     27931: {
         name: "Splintermark",
@@ -9689,7 +9612,8 @@ const RANGED_WEAPONS = {
         speed: 2.5,
         Phase: 1,
         icon: "inv_weapon_bow_04",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Vendor"
     },
     27987: {
         name: "Melmorta's Twilight Longbow",
@@ -9704,7 +9628,8 @@ const RANGED_WEAPONS = {
         speed: 3,
         Phase: 1,
         icon: "inv_weapon_bow_19",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Dungeon"
     },
     28286: {
         name: "Telescopic Sharprifle",
@@ -9719,7 +9644,8 @@ const RANGED_WEAPONS = {
         speed: 3,
         Phase: 1,
         icon: "inv_weapon_rifle_22",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Dungeon"
     },
     28294: {
         name: "Gladiator's Heavy Crossbow",
@@ -9735,7 +9661,8 @@ const RANGED_WEAPONS = {
         speed: 3.1,
         Phase: 1,
         icon: "inv_weapon_crossbow_10",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Arena Reward"
     },
     28397: {
         name: "Emberhawk Crossbow",
@@ -9750,7 +9677,8 @@ const RANGED_WEAPONS = {
         speed: 3,
         Phase: 1,
         icon: "inv_weapon_crossbow_17",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Dungeon"
     },
     28504: {
         name: "Steelhawk Crossbow",
@@ -9765,7 +9693,8 @@ const RANGED_WEAPONS = {
         speed: 2.8,
         Phase: 1,
         icon: "inv_weapon_crossbow_18",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Karazhan"
     },
     28581: {
         name: "Wolfslayer Sniper Rifle",
@@ -9780,7 +9709,8 @@ const RANGED_WEAPONS = {
         speed: 2.7,
         Phase: 1,
         icon: "inv_weapon_rifle_23",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Karazhan"
     },
     28772: {
         name: "Sunfury Bow of the Phoenix",
@@ -9795,7 +9725,8 @@ const RANGED_WEAPONS = {
         speed: 2.9,
         Phase: 1,
         icon: "inv_weapon_bow_18",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Karazhan"
     },
     29115: {
         name: "Consortium Blaster",
@@ -9811,7 +9742,8 @@ const RANGED_WEAPONS = {
         speed: 2.4,
         Phase: 1,
         icon: "inv_weapon_rifle_07",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Reputation Reward"
     },
     29151: {
         name: "Veteran's Musket",
@@ -9827,7 +9759,8 @@ const RANGED_WEAPONS = {
         speed: 2.7,
         Phase: 1,
         icon: "inv_weapon_rifle_02",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Reputation Reward"
     },
     29152: {
         name: "Marksman's Bow",
@@ -9843,7 +9776,8 @@ const RANGED_WEAPONS = {
         speed: 2.8,
         Phase: 1,
         icon: "inv_weapon_bow_08",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Reputation Reward"
     },
     29351: {
         name: "Wrathtide Longbow",
@@ -9858,7 +9792,8 @@ const RANGED_WEAPONS = {
         speed: 3,
         Phase: 1,
         icon: "inv_weapon_crossbow_16",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Dungeon"
     },
     29949: {
         name: "Arcanite Steam-Pistol",
@@ -9872,7 +9807,8 @@ const RANGED_WEAPONS = {
         speed: 2.9,
         Phase: 2,
         icon: "inv_weapon_rifle_18",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Serpentshrine Cavern"
     },
     30105: {
         name: "Serpent Spine Longbow",
@@ -9888,7 +9824,8 @@ const RANGED_WEAPONS = {
         speed: 3,
         Phase: 2,
         icon: "inv_weapon_bow_08",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Serpentshrine Cavern"
     },
     30226: {
         name: "Alley's Recurve",
@@ -9905,7 +9842,8 @@ const RANGED_WEAPONS = {
         speed: 2.5,
         Phase: 1,
         icon: "inv_weapon_bow_03",
-        quality: "Uncommon"
+        quality: "Uncommon",
+        Location: "Quest Reward"
     },
     30279: {
         name: "Mama's Insurance",
@@ -9921,7 +9859,8 @@ const RANGED_WEAPONS = {
         speed: 2.2,
         Phase: 1,
         icon: "inv_weapon_rifle_06",
-        quality: "Uncommon"
+        quality: "Uncommon",
+        Location: "Quest Reward"
     },
     30397: {
         name: "Spymaster's Crossbow",
@@ -9937,7 +9876,8 @@ const RANGED_WEAPONS = {
         speed: 2.7,
         Phase: 1,
         icon: "inv_weapon_crossbow_14",
-        quality: "Uncommon"
+        quality: "Uncommon",
+        Location: "Quest Reward"
     },
     30724: {
         name: "Barrel-Blade Longrifle",
@@ -9957,7 +9897,8 @@ const RANGED_WEAPONS = {
         speed: 2.6,
         Phase: 1,
         icon: "inv_weapon_rifle_22",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "World Boss"
     },
     30906: {
         name: "Bristleblitz Striker",
@@ -9971,7 +9912,8 @@ const RANGED_WEAPONS = {
         speed: 3,
         Phase: 3,
         icon: "inv_weapon_bow_30",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Mount Hyjal"
     },
     31000: {
         name: "Bloodwarder's Rifle",
@@ -9987,7 +9929,8 @@ const RANGED_WEAPONS = {
         speed: 2.6,
         Phase: 1,
         icon: "inv_weapon_rifle_07",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Quest Reward"
     },
     31072: {
         name: "Lohn'goron, Bow of the Torn-heart",
@@ -10002,7 +9945,8 @@ const RANGED_WEAPONS = {
         speed: 2.6,
         Phase: 1,
         icon: "inv_weapon_bow_16",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Quest Reward"
     },
     31204: {
         name: "The Gunblade",
@@ -10016,7 +9960,8 @@ const RANGED_WEAPONS = {
         speed: 2.8,
         Phase: 1,
         icon: "inv_weapon_rifle_07",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "World Drop"
     },
     31303: {
         name: "Valanos' Longbow",
@@ -10032,7 +9977,8 @@ const RANGED_WEAPONS = {
         speed: 2.8,
         Phase: 1,
         icon: "inv_weapon_bow_04",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "World Drop"
     },
     31323: {
         name: "Don Santos' Famous Hunting Rifle",
@@ -10052,7 +9998,8 @@ const RANGED_WEAPONS = {
         },
         Phase: 1,
         icon: "inv_weapon_rifle_21",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "World Drop"
     },
     31416: {
         name: "Scorch Wood Bow",
@@ -10068,7 +10015,8 @@ const RANGED_WEAPONS = {
         speed: 2.2,
         Phase: 1,
         icon: "inv_weapon_bow_08",
-        quality: "Uncommon"
+        quality: "Uncommon",
+        Location: "Quest Reward"
     },
     31986: {
         name: "Merciless Gladiator's Crossbow of the Phoenix",
@@ -10084,7 +10032,8 @@ const RANGED_WEAPONS = {
         speed: 3,
         Phase: 2,
         icon: "inv_weapon_crossbow_10",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Arena Reward"
     },
     32253: {
         name: "Legionkiller",
@@ -10098,7 +10047,8 @@ const RANGED_WEAPONS = {
         speed: 2.9,
         Phase: 3,
         icon: "inv_weapon_crossbow_20",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Black Temple"
     },
     32325: {
         name: "Rifle of the Stoic Guardian",
@@ -10111,7 +10061,8 @@ const RANGED_WEAPONS = {
         speed: 1.9,
         Phase: 3,
         icon: "inv_weapon_rifle_21",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Black Temple"
     },
     32336: {
         name: "Black Bow of the Betrayer",
@@ -10125,7 +10076,8 @@ const RANGED_WEAPONS = {
         speed: 3,
         Phase: 3,
         icon: "inv_weapon_bow_31",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Black Temple"
     },
     32645: {
         name: "Crystalline Crossbow",
@@ -10140,7 +10092,8 @@ const RANGED_WEAPONS = {
         speed: 2.8,
         Phase: 3,
         icon: "inv_weapon_crossbow_14",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Reputation Reward"
     },
     32756: {
         name: "Gyro-Balanced Khorium Destroyer",
@@ -10159,7 +10112,8 @@ const RANGED_WEAPONS = {
         speed: 2.8,
         Phase: 3,
         icon: "inv_weapon_rifle_13",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Crafted"
     },
     33006: {
         name: "Vengeful Gladiator's Heavy Crossbow",
@@ -10175,7 +10129,8 @@ const RANGED_WEAPONS = {
         speed: 3,
         Phase: 3,
         icon: "inv_weapon_crossbow_19",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Arena Reward"
     },
     33474: {
         name: "Ancient Amani Longbow",
@@ -10190,7 +10145,8 @@ const RANGED_WEAPONS = {
         speed: 3,
         Phase: 4,
         icon: "inv_weapon_bow_32",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Zul'Aman"
     },
     33491: {
         name: "Tuskbreaker",
@@ -10205,7 +10161,8 @@ const RANGED_WEAPONS = {
         speed: 2.9,
         Phase: 4,
         icon: "inv_weapon_rifle_24",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Zul'Aman"
     },
     34196: {
         name: "Golden Bow of Quel'Thalas",
@@ -10221,7 +10178,8 @@ const RANGED_WEAPONS = {
         speed: 3,
         Phase: 5,
         icon: "inv_weapon_bow_38",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Sunwell"
     },
     34334: {
         name: "Thori'dal, the Stars Fury",
@@ -10236,9 +10194,10 @@ const RANGED_WEAPONS = {
         mindmg: 356,
         maxdmg: 524,
         speed: 2.7,
-        Phase: 1,
+        Phase: 5,
         icon: "inv_weapon_bow_39",
-        quality: "Legendary"
+        quality: "Legendary",
+        Location: "Sunwell"
     },
     34529: {
         name: "Vengeful Gladiator's Longbow",
@@ -10254,7 +10213,8 @@ const RANGED_WEAPONS = {
         speed: 3,
         Phase: 3,
         icon: "inv_weapon_bow_20",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Arena Reward"
     },
     34530: {
         name: "Vengeful Gladiator's Rifle",
@@ -10270,7 +10230,8 @@ const RANGED_WEAPONS = {
         speed: 3,
         Phase: 3,
         icon: "inv_weapon_rifle_15",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Arena Reward"
     },
     34674: {
         name: "Truestrike Crossbow",
@@ -10287,7 +10248,8 @@ const RANGED_WEAPONS = {
         speed: 2.6,
         Phase: 1,
         icon: "inv_weapon_crossbow_14",
-        quality: "Rare"
+        quality: "Rare",
+        Location: "Reputation Reward"
     },
     34892: {
         name: "Crossbow of Relentless Strikes",
@@ -10303,7 +10265,8 @@ const RANGED_WEAPONS = {
         speed: 2.8,
         Phase: 5,
         icon: "inv_weapon_crossbow_26",
-        quality: "Epic"
+        quality: "Epic",
+        Location: "Badge Reward"
     }
 }
 
@@ -12762,7 +12725,7 @@ const WAISTS = {
         icon: "inv_belt_25",
         quality: "Rare"
     },
-    27637: {
+    32265: {
         name: "Shadow-walker's Cord",
         stats: {
             Agi: 27,
@@ -12773,8 +12736,8 @@ const WAISTS = {
         },
         Location: "Black Temple",
         Phase: 3,
-        icon: "inv_belt_15",
-        quality: "Rare"
+        icon: "inv_belt_26",
+        quality: "Epic"
     },
     27646: {
         name: "Marksman's Belt",
@@ -13178,7 +13141,7 @@ const WAISTS = {
         icon: "inv_belt_23",
         quality: "Uncommon"
     },
-    32265: {
+    27637: {
         name: "Shadowstalker's Sash",
         stats: {
             Agi: 17,
@@ -13190,8 +13153,8 @@ const WAISTS = {
         },
         Location: "PvP Reward",
         Phase: 1,
-        icon: "inv_belt_26",
-        quality: "Epic"
+        icon: "inv_belt_15",
+        quality: "Rare"
     },
     32346: {
         name: "Boneweave Girdle",

--- a/js/data/gear.js
+++ b/js/data/gear.js
@@ -740,7 +740,7 @@ const BACKS = {
             ArP: 112
         },
         Location: "Badge Reward",
-        Phase: 3,
+        Phase: 4,
         icon: "inv_misc_cape_20",
         quality: "Epic"
     },
@@ -1855,7 +1855,7 @@ const CHESTS = {
             MAP: 8,
             RAP: 8
         },
-        Phase: 1,
+        Phase: 5,
         icon: "inv_chest_chain_17",
         quality: "Epic"
     },
@@ -1877,7 +1877,7 @@ const CHESTS = {
             MAP: 4,
             RAP: 4
         },
-        Phase: 3,
+        Phase: 5,
         icon: "inv_chest_chain_17",
         quality: "Epic"
     },
@@ -1897,7 +1897,7 @@ const CHESTS = {
         socketBonus: {
             Stam: 3
         },
-        Phase: 3,
+        Phase: 5,
         icon: "inv_chest_plate02",
         quality: "Epic"
     },
@@ -2526,7 +2526,7 @@ const FEET = {
         socketBonus: {
             Hit: 3
         },
-        Phase: 3,
+        Phase: 4,
         icon: "inv_boots_07",
         quality: "Epic"
     },
@@ -2792,7 +2792,7 @@ const HANDS = {
             Hit: 17
         },
         Location: "Badge Reward",
-        Phase: 3,
+        Phase: 4,
         icon: "inv_gauntlets_01",
         quality: "Rare"
     },
@@ -3137,7 +3137,7 @@ const HANDS = {
         icon: "inv_gauntlets_03",
         quality: "Uncommon"
     },
-    31796: {
+    34234: {
         name: "Shadowed Gauntlets of Paroxysm",
         stats: {
             Agi: 41,
@@ -3155,8 +3155,8 @@ const HANDS = {
             Agi: 3
         },
         Phase: 5,
-        icon: "inv_gauntlets_14",
-        quality: "Uncommon"
+        icon: "inv_gauntlets_28",
+        quality: "Epic"
     },
     31961: {
         name: "Merciless Gladiator's Chain Gauntlets",
@@ -3274,7 +3274,7 @@ const HANDS = {
             Haste: 25
         },
         Location: "Badge Reward",
-        Phase: 3,
+        Phase: 5,
         icon: "inv_gauntlets_50",
         quality: "Epic"
     },
@@ -3298,7 +3298,7 @@ const HANDS = {
         icon: "inv_gauntlets_59",
         quality: "Epic"
     },
-    34234: {
+    31796: {
         name: "Sha'tari Marksman's Gloves",
         stats: {
             Agi: 20,
@@ -3309,8 +3309,8 @@ const HANDS = {
         },
         Location: "Quest Reward",
         Phase: 1,
-        icon: "inv_gauntlets_28",
-        quality: "Epic"
+        icon: "inv_gauntlets_14",
+        quality: "Uncommon"
     },
     34343: {
         name: "Thalassian Ranger Gauntlets",
@@ -3397,7 +3397,7 @@ const HANDS = {
         socketBonus: {
             Agi: 2
         },
-        Phase: 3,
+        Phase: 5,
         icon: "inv_gauntlets_25",
         quality: "Epic"
     },
@@ -5098,7 +5098,7 @@ const LEGS = {
             ArP: 175
         },
         Location: "Badge Reward",
-        Phase: 3,
+        Phase: 5,
         icon: "inv_pants_leather_23",
         quality: "Epic"
     },
@@ -5222,7 +5222,7 @@ const LEGS = {
         socketBonus: {
             Agi: 3
         },
-        Phase: 3,
+        Phase: 4,
         icon: "inv_pants_mail_05",
         quality: "Epic"
     },
@@ -7814,13 +7814,13 @@ const MELEE_WEAPONS = {
             RAP: 22,
             Hit: 12
         },
-        Location: "Reputation Reward",
+        Location: "Zul'Aman",
         type: "dagger",
         speed: 1.8,
         mindmg: 79,
         maxdmg: 120,
         hand: "One",
-        Phase: 1,
+        Phase: 4,
         icon: "inv_sword_107",
         quality: "Epic"
     },
@@ -8573,7 +8573,7 @@ const MELEE_WEAPONS = {
         mindmg: 180,
         maxdmg: 335,
         hand: "Main",
-        Phase: 4,
+        Phase: 5,
         icon: "inv_weapon_hand_16",
         quality: "Epic"
     },
@@ -8609,7 +8609,7 @@ const MELEE_WEAPONS = {
         mindmg: 108,
         maxdmg: 201,
         hand: "Off",
-        Phase: 3,
+        Phase: 5,
         icon: "inv_weapon_shortblade_78",
         quality: "Epic"
     },
@@ -8663,7 +8663,7 @@ const MELEE_WEAPONS = {
         mindmg: 130,
         maxdmg: 241,
         hand: "Off",
-        Phase: 3,
+        Phase: 5,
         icon: "inv_weapon_shortblade_78",
         quality: "Epic"
     }
@@ -13272,7 +13272,7 @@ const WAISTS = {
             ArP: 70
         },
         Location: "Badge Reward",
-        Phase: 3,
+        Phase: 4,
         icon: "inv_belt_22",
         quality: "Epic"
     },
@@ -13332,7 +13332,7 @@ const WAISTS = {
         socketBonus: {
             Agi: 2
         },
-        Phase: 3,
+        Phase: 5,
         icon: "inv_belt_03",
         quality: "Epic"
     }
@@ -13853,7 +13853,7 @@ const WRISTS = {
             ArP: 105
         },
         Location: "Badge Reward",
-        Phase: 3,
+        Phase: 4,
         icon: "inv_bracer_02",
         quality: "Epic"
     },
@@ -13873,7 +13873,7 @@ const WRISTS = {
         socketBonus: {
             Crit: 2
         },
-        Phase: 3,
+        Phase: 4,
         icon: "inv_bracer_07",
         quality: "Epic"
     },

--- a/js/data/gems.js
+++ b/js/data/gems.js
@@ -295,7 +295,8 @@ const GEMS = {
       },
       Phase: 1,
       quality: "Rare",
-      icon: "inv_misc_gem_diamond_07"
+      icon: "inv_misc_gem_diamond_07",
+      desc: "1 Red, 2 Yellow"
   },
   25895: {
       name: "Enigmatic Skyfire Diamond",
@@ -310,7 +311,8 @@ const GEMS = {
       },
       Phase: 1,
       quality: "Rare",
-      icon: "inv_misc_gem_diamond_07"
+      icon: "inv_misc_gem_diamond_07",
+      desc: "More Red than Yellow"
   },
   25896: {
       name: "Powerful Earthstorm Diamond",
@@ -325,7 +327,8 @@ const GEMS = {
       },
       Phase: 1,
       quality: "Rare",
-      icon: "inv_misc_gem_diamond_06"
+      icon: "inv_misc_gem_diamond_06",
+      desc: "3 Blue"
   },
   25901: {
       name: "Insightful Earthstorm Diamond",
@@ -340,7 +343,8 @@ const GEMS = {
       },
       Phase: 1,
       quality: "Rare",
-      icon: "inv_misc_gem_diamond_06"
+      icon: "inv_misc_gem_diamond_06",
+      desc: "2 Red, 2 Yellow, 2 Blue"
   },
   27679: {
       name: "Sublime Mystic Dawnstone",
@@ -411,7 +415,8 @@ const GEMS = {
       },
       Phase: 1,
       quality: "Rare",
-      icon: "inv_misc_gem_diamond_07"
+      icon: "inv_misc_gem_diamond_07",
+      desc: "2 Yellow, 1 Red"
   },
   28595: {
       name: "Bright Blood Garnet",
@@ -901,7 +906,8 @@ const GEMS = {
       },
       Phase: 1,
       quality: "Rare",
-      icon: "inv_misc_gem_diamond_06"
+      icon: "inv_misc_gem_diamond_06",
+      desc: "2 Red, 2 Yellow, 2 Blue"
   },
   32410: {
       name: "Thundering Skyfire Diamond",
@@ -919,12 +925,12 @@ const GEMS = {
                 duration: 6,
             }
         }
-
         return bonus
       },
       Phase: 1,
       quality: "Rare",
-      icon: "inv_misc_gem_diamond_07"
+      icon: "inv_misc_gem_diamond_07",
+      desc: "2 Red, 2 Yellow, 2 Blue"
   },
   32634: {
       name: "Unstable Amethyst",
@@ -984,7 +990,8 @@ const GEMS = {
       },
       Phase: 1,
       quality: "Rare",
-      icon: "inv_misc_gem_diamond_07"
+      icon: "inv_misc_gem_diamond_07",
+      desc: "More Blue than Yellow"
   },
   33131: {
       name: "Crimson Sun",

--- a/js/data/gems.js
+++ b/js/data/gems.js
@@ -285,13 +285,15 @@ const GEMS = {
       meta: "Y",
       activation: gemsUsed => {
         const bonus = { swift_metagem_run_speed_increase: 1.00 }
+        var active = false;
 
         if (gemsUsed.yellow >= 2 && gemsUsed.red >= 1) {
             bonus.stats = { MAP: 24, RAP: 24 }
             bonus.swift_metagem_run_speed_increase = 1.08
+            active = true;
         }
 
-        return bonus
+        return { bonus, active }
       },
       Phase: 1,
       quality: "Rare",
@@ -303,11 +305,12 @@ const GEMS = {
       meta: "Y",
       activation: gemsUsed => {
         const bonus = {}
-
-        if (gemsUsed.red > gemsUsed.yellow)
+        var active = false;
+        if (gemsUsed.red > gemsUsed.yellow) {
             bonus.stats = { Crit: 12 }
-
-        return bonus
+            active = true;
+        }
+        return { bonus, active }
       },
       Phase: 1,
       quality: "Rare",
@@ -319,11 +322,12 @@ const GEMS = {
       meta: "Y",
       activation: gemsUsed => {
         const bonus = {}
-
-        if (gemsUsed.blue >= 3)
+        var active = false;
+        if (gemsUsed.blue >= 3) {
             bonus.stats = { Stam: 18 }
-
-        return bonus
+            active = true;
+        }
+        return { bonus, active }
       },
       Phase: 1,
       quality: "Rare",
@@ -335,11 +339,12 @@ const GEMS = {
       meta: "Y",
       activation: gemsUsed => {
         const bonus = {}
-
-        if (gemsUsed.red >= 2 && gemsUsed.yellow >= 2 && gemsUsed.blue >= 2)
+        var active = false;
+        if (gemsUsed.red >= 2 && gemsUsed.yellow >= 2 && gemsUsed.blue >= 2) {
             bonus.stats = { Int: 12 }
-
-        return bonus
+            active = true;
+        }
+        return { bonus, active }
       },
       Phase: 1,
       quality: "Rare",
@@ -405,13 +410,14 @@ const GEMS = {
       meta: "Y",
       activation: gemsUsed => {
         const bonus = { swift_metagem_run_speed_increase: 1.00 }
-
+        var active = false;
         if (gemsUsed.yellow >= 2 && gemsUsed.red >= 1) {
             bonus.stats = { MAP: 20, RAP: 20 }
             bonus.swift_metagem_run_speed_increase = 1.08
+            active = true;
         }
 
-        return bonus
+        return { bonus, active }
       },
       Phase: 1,
       quality: "Rare",
@@ -896,13 +902,14 @@ const GEMS = {
       meta: "Y",
       activation: gemsUsed => {
         const bonus = { relentless_metagem_crit_dmg_inc: 1.00 }
-
+        var active = false;
         if (gemsUsed.red >= 2 && gemsUsed.yellow >= 2 && gemsUsed.blue >= 2) {
             bonus.stats = { Agi: 12 }
             bonus.relentless_metagem_crit_dmg_inc = 1.03
+            active = true;
         }
 
-        return bonus
+        return { bonus, active }
       },
       Phase: 1,
       quality: "Rare",
@@ -914,7 +921,7 @@ const GEMS = {
       meta: "Y",
       activation: gemsUsed => {
         const bonus = {}
-
+        var active = false;
         if (gemsUsed.red >= 2 && gemsUsed.yellow >= 2 && gemsUsed.blue >= 2) {
             bonus.aura = {
                 stats: { Haste: 240 },
@@ -924,8 +931,9 @@ const GEMS = {
                 proc_type: 2,
                 duration: 6,
             }
+            active = true;
         }
-        return bonus
+        return { bonus, active }
       },
       Phase: 1,
       quality: "Rare",
@@ -984,9 +992,14 @@ const GEMS = {
       meta: "Y",
       activation: gemsUsed => {
         const bonus = {}
-        if (gemsUsed.blue > gemsUsed.yellow) bonus.stats = { MAP: 24, RAP: 24 }
+        var active = false;
+        if (gemsUsed.blue > gemsUsed.yellow) {
 
-        return bonus
+            bonus.stats = { MAP: 24, RAP: 24 }
+            active = true;
+        }
+        
+        return { bonus, active }
       },
       Phase: 1,
       quality: "Rare",

--- a/js/data/gems.js
+++ b/js/data/gems.js
@@ -20,7 +20,7 @@ const GEMS = {
           Agi: 6
       },
       Phase: 1,
-      quality: "Common",
+      quality: "Uncommon",
       icon: "inv_misc_gem_bloodgem_02"
   },
   23100: {
@@ -34,7 +34,7 @@ const GEMS = {
           Hit: 3
       },
       Phase: 1,
-      quality: "Common",
+      quality: "Uncommon",
       icon: "inv_misc_gem_flamespessarite_02"
   },
   23104: {
@@ -48,7 +48,7 @@ const GEMS = {
           Crit: 3
       },
       Phase: 1,
-      quality: "Common",
+      quality: "Uncommon",
       icon: "inv_misc_gem_deepperidot_02"
   },
   23106: {
@@ -62,7 +62,7 @@ const GEMS = {
           MP5: 1
       },
       Phase: 1,
-      quality: "Common",
+      quality: "Uncommon",
       icon: "inv_misc_gem_deepperidot_02"
   },
   23110: {
@@ -76,7 +76,7 @@ const GEMS = {
           Stam: 4
       },
       Phase: 1,
-      quality: "Common",
+      quality: "Uncommon",
       icon: "inv_misc_gem_ebondraenite_02"
   },
   23113: {
@@ -88,7 +88,7 @@ const GEMS = {
           Int: 6
       },
       Phase: 1,
-      quality: "Common",
+      quality: "Uncommon",
       icon: "inv_misc_gem_goldendraenite_02"
   },
   23116: {
@@ -100,7 +100,7 @@ const GEMS = {
           Hit: 6
       },
       Phase: 1,
-      quality: "Common",
+      quality: "Uncommon",
       icon: "inv_misc_gem_goldendraenite_02"
   },
   23118: {
@@ -112,7 +112,7 @@ const GEMS = {
           Stam: 9
       },
       Phase: 1,
-      quality: "Common",
+      quality: "Uncommon",
       icon: "inv_misc_gem_azuredraenite_02"
   },
   23121: {
@@ -124,7 +124,7 @@ const GEMS = {
           MP5: 2
       },
       Phase: 1,
-      quality: "Common",
+      quality: "Uncommon",
       icon: "inv_misc_gem_azuredraenite_02"
   },
   24028: {
@@ -379,7 +379,7 @@ const GEMS = {
           Crit: 6
       },
       Phase: 1,
-      quality: "Common",
+      quality: "Uncommon",
       icon: "inv_misc_gem_goldendraenite_02"
   },
   28361: {
@@ -395,91 +395,6 @@ const GEMS = {
       quality: "Rare",
       unique: true,
       icon: "inv_misc_gem_bloodstone_02"
-  },
-  28459: {
-      name: "Delicate Tourmaline",
-      colors: [
-          "red"
-      ],
-      stats: {
-          Agi: 4
-      },
-      Phase: 1,
-      quality: "Common",
-      icon: "inv_misc_gem_ruby_03"
-  },
-  28462: {
-      name: "Bright Tourmaline",
-      colors: [
-          "red"
-      ],
-      stats: {
-          MAP: 8,
-          RAP: 8
-      },
-      Phase: 1,
-      quality: "Common",
-      icon: "inv_misc_gem_ruby_03"
-  },
-  28463: {
-      name: "Solid Zircon",
-      colors: [
-          "blue"
-      ],
-      stats: {
-          Stam: 6
-      },
-      Phase: 1,
-      quality: "Common",
-      icon: "inv_misc_gem_crystal_03"
-  },
-  28465: {
-      name: "Lustrous Zircon",
-      colors: [
-          "blue"
-      ],
-      stats: {
-          MP5: 1
-      },
-      Phase: 1,
-      quality: "Common",
-      icon: "inv_misc_gem_crystal_03"
-  },
-  28466: {
-      name: "Brilliant Amber",
-      colors: [
-          "yellow"
-      ],
-      stats: {
-          Int: 4
-      },
-      Phase: 1,
-      quality: "Common",
-      icon: "inv_misc_gem_topaz_03"
-  },
-  28467: {
-      name: "Smooth Amber",
-      colors: [
-          "yellow"
-      ],
-      stats: {
-          Crit: 4
-      },
-      Phase: 1,
-      quality: "Common",
-      icon: "inv_misc_gem_topaz_03"
-  },
-  28468: {
-      name: "Rigid Amber",
-      colors: [
-          "yellow"
-      ],
-      stats: {
-          Hit: 4
-      },
-      Phase: 1,
-      quality: "Common",
-      icon: "inv_misc_gem_topaz_03"
   },
   28556: {
       name: "Swift Windfire Diamond",
@@ -508,7 +423,7 @@ const GEMS = {
           RAP: 12
       },
       Phase: 1,
-      quality: "Common",
+      quality: "Uncommon",
       icon: "inv_misc_gem_bloodgem_02"
   },
   30549: {
@@ -708,7 +623,7 @@ const GEMS = {
           RAP: 6
       },
       Phase: 1,
-      quality: "Common",
+      quality: "Uncommon",
       icon: "inv_misc_gem_ebondraenite_02"
   },
   31863: {
@@ -738,7 +653,7 @@ const GEMS = {
           MP5: 1
       },
       Phase: 1,
-      quality: "Common",
+      quality: "Uncommon",
       icon: "inv_misc_gem_ebondraenite_02"
   },
   31865: {
@@ -783,7 +698,7 @@ const GEMS = {
           Crit: 3
       },
       Phase: 1,
-      quality: "Common",
+      quality: "Uncommon",
       icon: "inv_misc_gem_flamespessarite_02"
   },
   32194: {
@@ -807,7 +722,7 @@ const GEMS = {
           Stam: 15
       },
       Phase: 3,
-      quality: "Rare",
+      quality: "Epic",
       icon: "inv_jewelcrafting_empyreansapphire_02"
   },
   32202: {
@@ -819,7 +734,7 @@ const GEMS = {
           MP5: 4
       },
       Phase: 3,
-      quality: "Rare",
+      quality: "Epic",
       icon: "inv_jewelcrafting_empyreansapphire_02"
   },
   32204: {
@@ -881,7 +796,7 @@ const GEMS = {
           Stam: 7
       },
       Phase: 3,
-      quality: "Rare",
+      quality: "Epic",
       icon: "inv_jewelcrafting_shadowsongamethyst_02"
   },
   32213: {
@@ -896,7 +811,7 @@ const GEMS = {
           RAP: 10
       },
       Phase: 3,
-      quality: "Rare",
+      quality: "Epic",
       icon: "inv_jewelcrafting_shadowsongamethyst_02"
   },
   32214: {
@@ -911,7 +826,7 @@ const GEMS = {
           MP5: 2
       },
       Phase: 3,
-      quality: "Rare",
+      quality: "Epic",
       icon: "inv_jewelcrafting_shadowsongamethyst_02"
   },
   32220: {
@@ -925,7 +840,7 @@ const GEMS = {
           Hit: 5
       },
       Phase: 3,
-      quality: "Rare",
+      quality: "Epic",
       icon: "inv_jewelcrafting_pyrestone_02"
   },
   32222: {
@@ -940,7 +855,7 @@ const GEMS = {
           Crit: 5
       },
       Phase: 3,
-      quality: "Rare",
+      quality: "Epic",
       icon: "inv_jewelcrafting_pyrestone_02"
   },
   32225: {
@@ -954,7 +869,7 @@ const GEMS = {
           MP5: 2
       },
       Phase: 3,
-      quality: "Rare",
+      quality: "Epic",
       icon: "inv_jewelcrafting_seasprayemerald_02"
   },
   32226: {
@@ -968,7 +883,7 @@ const GEMS = {
           Crit: 5
       },
       Phase: 3,
-      quality: "Rare",
+      quality: "Epic",
       icon: "inv_jewelcrafting_seasprayemerald_02"
   },
   32409: {

--- a/js/datastorage.js
+++ b/js/datastorage.js
@@ -14,6 +14,9 @@ function storeData(){
     localStorage.setItem('pet_consumes',JSON.stringify(petconsumes));
     // debuffs
     localStorage.setItem('debuffs',JSON.stringify(debuffs));
+    // partybuffs
+    localStorage.setItem('partybuffs',JSON.stringify(partybuffs));
+
     
     localStorage.setItem('flask',document.getElementById("flask").value);
     localStorage.setItem('battle',document.getElementById("battle").value);
@@ -95,6 +98,7 @@ function fetchData(){
     petconsumes = (JSON.parse(localStorage.getItem('pet_consumes')) != null) ? JSON.parse(localStorage.getItem('pet_consumes')):petconsumes;
     // debuffs
     debuffs = (JSON.parse(localStorage.getItem('debuffs')) != null) ? JSON.parse(localStorage.getItem('debuffs')):debuffs;
+    partybuffs = (JSON.parse(localStorage.getItem('partybuffs')) != null) ? JSON.parse(localStorage.getItem('partybuffs')):partybuffs;
     // saves each value below as a string - fight settings
     iterations = (parseInt(localStorage.getItem('iterations')) != null) ? parseInt(localStorage.getItem('iterations')) : iterations;
     minfighttimer = (parseInt(localStorage.getItem('minfight')) != null) ? parseInt(localStorage.getItem('minfight')) : minfighttimer;
@@ -140,7 +144,6 @@ function fetchData(){
     auras.aptrink1.offset = (localStorage.getItem('trink1offset') != null) ? parseInt(localStorage.getItem('trink1offset')):auras.aptrink1.offset;
     auras.aptrink2.offset = (localStorage.getItem('trink2offset') != null) ? parseInt(localStorage.getItem('trink2offset')):auras.aptrink2.offset;
     auras.potion.offset = (localStorage.getItem('startpotoffset') != null) ? parseInt(localStorage.getItem('startpotoffset')):auras.potion.offset;
-    //auras.rune.offset = (localStorage.getItem('runeoffset') != null) ? parseInt(localStorage.getItem('runeoffset')):auras.rune.offset;
 
     // spell option
     let lustoption = '';
@@ -267,6 +270,9 @@ function fetchData(){
     document.getElementById("misuptime").value = debuffs.misery.uptime_g;
     document.getElementById("coeuptime").value = debuffs.curseofele.uptime_g;
     document.getElementById("coebonus").selected = debuffs.curseofele.improved ? true : false;
+    document.getElementById("unlrageuptime").value = partybuffs.unleashedrage.uptime_g;
+    document.getElementById("ferocuptime").value = partybuffs.ferociousinsp.uptime_g;
+    document.getElementById("ferocstacks").value = partybuffs.ferociousinsp.stacks;
 
     // spell enables
     document.getElementById("rapidcheck").checked = auras.rapid.enable;
@@ -290,7 +296,6 @@ function fetchData(){
     document.getElementById("trink1offset").value = auras.aptrink1.offset;
     document.getElementById("trink2offset").value = auras.aptrink2.offset;
     document.getElementById("startpotoffset").value = auras.potion.offset;
-    //document.getElementById("runeoffset").value = auras.rune.offset;
     // spell options
     document.getElementById("lustoption").value = lustoption;
     document.getElementById("drumoption").value = auras.drums.type;

--- a/js/gearui.js
+++ b/js/gearui.js
@@ -558,7 +558,10 @@ function textColorDisplay(slot,array){
 
 function estimateDps(item, weights) {
     let dps = 0;
-
+    if (item.name == 'Relentless Earthstorm Diamond') {
+        dps += weights.relentless + weights.Agi * 12;
+        return dps;
+    }
     if (!!item.stats) {
         dps = Object.entries(item.stats).reduce((acc, [stat, value]) => acc + (weights[stat] || 0) * value, 0)
     } else { return 0 }
@@ -568,7 +571,7 @@ function estimateDps(item, weights) {
             dps + estimateDps(GEMS[preferredGems[socket]], weights),
             estimateDps({ stats: item.socketBonus }, weights)
       )
-  
+    
     dps += allRed > matchingSockets ? allRed : matchingSockets
     }
     return dps

--- a/js/gearui.js
+++ b/js/gearui.js
@@ -25,6 +25,7 @@ var preferredGems = {
     Meta: 32409
 }
 
+var gemsTotalsEquipped = {};
 // on click listeners for slots and enchants
 document.getElementById("headench").addEventListener("click", function(){gearModalDisplay("head")}, false);
 document.getElementById("shoulderench").addEventListener("click", function(){gearModalDisplay("shoulder")}, false);
@@ -605,6 +606,13 @@ function estimateDps(item, weights) {
             dps += weights.Agi * 20;
         }
     }
+    if (activeslot == 'mainhand' && !!item.type && SPELLS.raptorstrike.enable) {
+        dps += item.speed * 30 + ((item.mindmg + item.maxdmg) / 2) / item.speed * 0.46;
+    } else if (activeslot == 'range' && !!item.type && item.name == "Thori'dal, the Stars Fury") {
+        dps += item.speed * 50 + ((item.mindmg + item.maxdmg) / 2) / item.speed * 5.8 / 1.25;
+    } else if (activeslot == 'range' && !!item.type) {
+        dps += item.speed * 50 + ((item.mindmg + item.maxdmg) / 2) / item.speed * 5.8;
+    }
     // add stats
     if (!!item.stats) {
         dps += Object.entries(item.stats).reduce((acc, [stat, value]) => acc + (weights[stat] || 0) * value, 0)
@@ -703,7 +711,7 @@ function unequipItemFromGear(){
     }
     gearModalDisplay(activeslot);
 }
-
+/** takes a given input and filters a given table based on slot, tab selected. */
 function filterField(input , table) {
     var input, filter, table, tr, td, i, txtValue;
     
@@ -727,6 +735,7 @@ function filterField(input , table) {
     }
 }
 
+/** Generates the table bodies for displaying sorted gear/gem/enchants */
 function generateGearTbodies(array, fnc, idname, lookup, hrefdata, locdata){
 
     let tbody = document.getElementById(idname);
@@ -770,9 +779,10 @@ function generateGearTbodies(array, fnc, idname, lookup, hrefdata, locdata){
         tbody.innerHTML = final;
 }
 
+/** Initial function to generate tables for gear/gems/enchants */
 function generateGearTable(array, type) {
 
-    let start = performance.now();
+    //let start = performance.now();
     let arraylength = array.length;
     let currgear = gear[activeslot];
     let i = 0;
@@ -815,9 +825,9 @@ function generateGearTable(array, type) {
 
     generateGearTbodies(array, fnc, idname, lookup, hrefdata, locdata);
 
-    let end = performance.now();
-    let execute = (end - start) / 1000; // milliseconds convert to sec
-    console.log("generateGearTable "+execute.toFixed(3));
+    //let end = performance.now();
+    //let execute = (end - start) / 1000; // milliseconds convert to sec
+    //console.log("generateGearTable "+execute.toFixed(3));
 }
 
 function displayCurrentGearTabs(){
@@ -883,6 +893,23 @@ function displayCurrentGearTabs(){
     prevslot = activeslot;
 }
 
+/** Changes color and description of meta gem for seeing if it's active */
+function setMetaDisplay(metagem) {
+
+    let metadata = GEMS[metagem];
+    document.getElementById("metareq").innerHTML = "Meta: " + metadata.desc;
+
+    let metacheck = metadata.activation(gemsTotalsEquipped);
+    if (metacheck.active) {
+        document.getElementById("metareq").classList.remove("meta-req-fail");
+        document.getElementById("metareq").classList.add("meta-req-met");
+    }
+    else {
+        document.getElementById("metareq").classList.remove("meta-req-met");
+        document.getElementById("metareq").classList.add("meta-req-fail");
+    }
+}
+
 function gearSlotsDisplay(){
     
     let headitem = gear.head.id;
@@ -935,6 +962,9 @@ function gearSlotsDisplay(){
         if(headgem1 === 0){
             document.getElementsByClassName("gemskt")[0].style.visibility = "hidden";
         } else {
+            if (!!GEMS[headgem1].meta) {
+                setMetaDisplay(headgem1);
+            }
             document.getElementsByClassName("gemskt")[0].src = "https://wow.zamimg.com/images/wow/icons/large/"+GEMS[headgem1].icon+".jpg";
             document.getElementsByClassName("gemskt")[0].style.visibility = "visible";
         }
@@ -942,6 +972,9 @@ function gearSlotsDisplay(){
         if(headgem2 === 0){
             document.getElementsByClassName("gemskt")[1].style.visibility = "hidden";
         } else {
+            if (!!GEMS[headgem2].meta) {
+                setMetaDisplay(headgem2);
+            }
             document.getElementsByClassName("gemskt")[1].src = "https://wow.zamimg.com/images/wow/icons/large/"+GEMS[headgem2].icon+".jpg";
             document.getElementsByClassName("gemskt")[1].style.visibility = "visible";
         }
@@ -949,6 +982,9 @@ function gearSlotsDisplay(){
         if(headgem3 === 0){
             document.getElementsByClassName("gemskt")[2].style.visibility = "hidden";
         } else {
+            if (!!GEMS[headgem3].meta) {
+                setMetaDisplay(headgem3);
+            }
             document.getElementsByClassName("gemskt")[2].src = "https://wow.zamimg.com/images/wow/icons/large/"+GEMS[headgem3].icon+".jpg";
             document.getElementsByClassName("gemskt")[2].style.visibility = "visible";
         }

--- a/js/importer.js
+++ b/js/importer.js
@@ -17,7 +17,6 @@ const GEAR_MAPPER = {
   TRINKET_2: 'trinket2',
   RANGED: 'range'
 }
-const INITIAL_GEAR = { ammo: { id: 33803 }, quiver: { id: 18714 }}
 
 function findEnchantByEffectId(pieceName, effectId) {
   let enchantId = Object.keys(ENCHANT_MAP[pieceName]).find(id => ENCHANT_MAP[pieceName][id].effectId === effectId)
@@ -27,13 +26,6 @@ function findEnchantByEffectId(pieceName, effectId) {
 }
 
 const INITIAL_GEAR = { ammo: { id: 33803 }, quiver: { id: 18714 }}
-
-function findEnchantByEffectId(pieceName, effectId) {
-  let enchantId = Object.keys(ENCHANT_MAP[pieceName]).find(id => ENCHANT_MAP[pieceName][id].effectId === effectId)
-
-  if (enchantId <= 0) throw new Error(`Unknown enchant with effect id ${effectId}`)
-  return Number(enchantId)
-}
 
 function importGearFrom70U(items) {
   const gear = { ...INITIAL_GEAR }

--- a/js/importer.js
+++ b/js/importer.js
@@ -18,8 +18,17 @@ const GEAR_MAPPER = {
   RANGED: 'range'
 }
 
+const INITIAL_GEAR = { ammo: { id: 33803 }, quiver: { id: 18714 }}
+
+function findEnchantByEffectId(pieceName, effectId) {
+  let enchantId = Object.keys(ENCHANT_MAP[pieceName]).find(id => ENCHANT_MAP[pieceName][id].effectId === effectId)
+
+  if (enchantId <= 0) throw new Error(`Unknown enchant with effect id ${effectId}`)
+  return Number(enchantId)
+}
+
 function importGearFrom70U(items) {
-  const gear = { ammo: { id: 33803 }, quiver: { id: 18714 }}
+  const gear = { ...INITIAL_GEAR }
 
   items.forEach(item => {
     const gearPiece = {}
@@ -28,11 +37,7 @@ function importGearFrom70U(items) {
 
     gearPiece.id = item.id
     if (item.gems) gearPiece.gems = item.gems.map(gem => gem.id)
-    if (item.enchant?.id) {
-      let enchantId = Object.keys(ENCHANT_MAP[pieceName]).find(id => ENCHANT_MAP[pieceName][id].effectId === item.enchant.id)
-      if (enchantId > 0) gearPiece.enchant = Number(enchantId)
-      else throw new Error(`Unknown enchant with effect id ${item.enchant.id}`)
-    }
+    if (item.enchant?.id) gearPiece.enchant = findEnchantByEffectId(pieceName, item.enchant.id)
 
     gear[pieceName] = gearPiece
   })
@@ -58,4 +63,35 @@ function importFrom70U(data) {
     gear: importGearFrom70U(items),
     talents: importTalentsFrom70U(talents)
   }
+}
+
+const GEAR_ORDER = ['ammo', 'head', 'neck', 'shoulder', 'shirt', 'chest', 'waist', 'leg', 'feet', 'wrist', 'hand', 'ring1', 'ring2', 'trinket1', 'trinket2', 'back', 'mainhand', 'offhand', 'range', 'tabard']
+const TO_SKIP = [0, 4, 19]
+
+function importFromWA(data) {
+  const gear = { ...INITIAL_GEAR }
+  if (data[0] !== '{' || data[data.length - 1] !== '}') throw new Error('ImportFromWA received invalid input')
+
+  data.slice(1, -1).split(',').forEach((line, i) => {
+    if (!line) return
+
+    const [idx,,id, enchant, gem1, gem2, gem3] = line.split(':')
+    if (TO_SKIP.includes(Number(idx))) return
+    if (idx !== i.toString()) throw new Error('ImportFromWA received invalid input')
+
+    if (id) {
+      const piece = { id: Number(id) }
+      const pieceName = GEAR_ORDER[idx]
+
+      if (enchant) piece.enchant = findEnchantByEffectId(pieceName, Number(enchant))
+      if (gem1 || gem2 || gem3) piece.gems = []
+      if (gem1) piece.gems[0] = Number(gem1)
+      if (gem2) piece.gems[1] = Number(gem2)
+      if (gem3) piece.gems[2] = Number(gem3)
+
+      gear[pieceName] = piece
+    }
+  })
+
+  return gear
 }

--- a/js/pet.js
+++ b/js/pet.js
@@ -39,6 +39,7 @@ var petautodmg = 0;
 var petduration = 0;
 var petsteptime = 0;
 var spellindex = 0;
+var beast_tame_weight = false;
 
 var PETS = [
     { 
@@ -86,7 +87,7 @@ function petStatsCalc(){
     let racialmod = (selectedRace === 3) ? 1.05 : 1; // 5% pet dmg if orc
     let beasttamers_crit = 0;
     let beasttamers_dmg = 1;
-    if (gear.shoulder.id === 30892) {
+    if (gear.shoulder.id === 30892 || beast_tame_weight) {
         beasttamers_dmg = 1.02;
         beasttamers_crit = 2;
     };
@@ -126,7 +127,7 @@ function petUpdateDmgMod(){
     pet.combatdmgmod = 1;
     if(auras.beastwithin.timer > 0) { pet.combatdmgmod *= 1.5; } // bestial wrath
     if(pet.ferocious.timer > 0) { pet.combatdmgmod *= talents.ferocious_insp; } // ferocious insp pet buff
-    //if(auras.ferocious.timer > 0) { pet.combatdmgmod *= 1.03 * BMHuntersInGroup; } // ferocious insp from others
+    if(partybuffs.ferociousinsp.timer > 0 && !partybuffs.ferociousinsp.inactive) { pet.combatdmgmod *= Math.pow(1.03, partybuffs.ferociousinsp.stacks); } // ferocious insp from others
     if(debuffs.bloodfrenzy.timer > 0 && !debuffs.bloodfrenzy.inactive) { pet.combatdmgmod *= 1.04;} // blood frenzy debuff
     return;
 }
@@ -161,6 +162,9 @@ function petUpdateStats(){
     else if (debuffs.exposeweakness.timer > 0 && !debuffs.exposeweakness.inactive) {
         pet.combatap += debuffs.exposeweakness.agi / 4;
     }
+    let unleashMAP = (partybuffs.unleashedrage.timer > 0 && !partybuffs.unleashedrage.inactive) ? 1.1 : 1;
+    pet.combatap *= unleashMAP;
+    // ******************** Crit *******************
     pet.combatcrit += combatAgi / 33;
     // pet crit imp crusader
     if(debuffs.judgecrusader.timer > 0 && !debuffs.judgecrusader.inactive) { 

--- a/js/player.js
+++ b/js/player.js
@@ -616,10 +616,10 @@ function updateDmgMod() {
 
    if(auras.beastwithin.timer > 0) { combatdmgmod *= 1.1;} // beast within
    if(pet.ferocious.timer > 0) { combatdmgmod *= talents.ferocious_insp; } // ferocious insp pet buff
-   if((partybuffs.ferociousinsp.timer > 0) && !partybuffs.ferociousinsp.inactive) { combatdmgmod *= 1.03 * partybuffs.ferociousinsp.stacks; } // ferocious insp from others
+   if((partybuffs.ferociousinsp.timer > 0) && !partybuffs.ferociousinsp.inactive) { combatdmgmod *= Math.pow(1.03, partybuffs.ferociousinsp.stacks); } // ferocious insp from others
    if((debuffs.bloodfrenzy.timer > 0) && !debuffs.bloodfrenzy.inactive) { physdmgmod *= 1.04; } // blood frenzy
    // special mods for non-physical dmg
-   if((debuffs.curseofele.timer > 0) && !debuffs.curseofele.inactive) { magdmgmod *= 1.1; } // curse of ele
+   if((debuffs.curseofele.timer > 0) && !debuffs.curseofele.inactive) { magdmgmod *= (debuffs.curseofele.improved) ? 1.13 : 1.1; } // curse of ele
    if((debuffs.misery.timer > 0) && !debuffs.misery.inactive) { magdmgmod *= 1.05; } // misery
    return;
 }

--- a/js/player.js
+++ b/js/player.js
@@ -64,6 +64,7 @@ var combatMAP = 0;
 var combatdmgmod = 1;
 var physdmgmod = 1;
 var magdmgmod = 1;
+var magdmgmod = 1;
 var naturedmgmod = 1;
 var haste = 1;
 
@@ -213,7 +214,7 @@ function checkWeaponType(){
    let equippedRangeType = RANGED_WEAPONS[gear.range.id].type; 
    let equippedMHType = MELEE_WEAPONS[gear.mainhand.id].type;
    // check for gun and dwarf, or bow and troll
-   if ((equippedRangeType === 'gun' && selectedRace === 1) || (equippedRangeType === 'bow' && selectedRace === 4)) {
+   if ((equippedRangeType === 'Gun' && selectedRace === 1) || (equippedRangeType === 'Bow' && selectedRace === 4)) {
       races[selectedRace].critchance = 1;
    } else {
       races[selectedRace].critchance = 0;
@@ -539,9 +540,11 @@ function updateAP() {
          HM_map = 110 * 1;
       }
    }
+
+   let unleashMAP = (partybuffs.unleashedrage.timer > 0 && !partybuffs.unleashedrage.inactive) ? 1.1 : 1;
    // totals AP - HM and targetAP do not buff pet
    combatRAP += (bonusAP + targetAP + HM_rap) * rapmod;
-   combatMAP += (bonusAP + targetAP + HM_map) * mapmod;
+   combatMAP += (bonusAP + targetAP + HM_map) * mapmod * unleashMAP;
 
    //console.log("rap: " + combatRAP);
    // returns AP used in the pet function call
@@ -606,14 +609,18 @@ function updateHaste() {
    return;
 }
 // handling for dmg mod changes from auras
-function updateDamageMod() {
+function updateDmgMod() {
    combatdmgmod = 1;
    physdmgmod = 1;
+   magdmgmod = 1;
+
    if(auras.beastwithin.timer > 0) { combatdmgmod *= 1.1;} // beast within
    if(pet.ferocious.timer > 0) { combatdmgmod *= talents.ferocious_insp; } // ferocious insp pet buff
-   if(debuffs.bloodfrenzy.timer > 0 && !debuffs.bloodfrenzy.inactive) { physdmgmod *= 1.04; } // blood frenzy
+   if((partybuffs.ferociousinsp.timer > 0) && !partybuffs.ferociousinsp.inactive) { combatdmgmod *= 1.03 * partybuffs.ferociousinsp.stacks; } // ferocious insp from others
+   if((debuffs.bloodfrenzy.timer > 0) && !debuffs.bloodfrenzy.inactive) { physdmgmod *= 1.04; } // blood frenzy
    // special mods for non-physical dmg
-
+   if((debuffs.curseofele.timer > 0) && !debuffs.curseofele.inactive) { magdmgmod *= 1.1; } // curse of ele
+   if((debuffs.misery.timer > 0) && !debuffs.misery.inactive) { magdmgmod *= 1.05; } // misery
    return;
 }
 
@@ -903,7 +910,7 @@ function cast(spell) {
    let spellcost = 0;
    updateAgi();
    updateAP();
-   updateDamageMod();
+   updateDmgMod();
 
    if(spell === 'autoshot'){
       attackRange();

--- a/js/simulation.js
+++ b/js/simulation.js
@@ -167,7 +167,7 @@ function loopSimHelper(callback, isStatWeights) {
         }
     }
     else if (currentiteration === iterations){
-        if (weightiteration === maxWeightIteration) {
+        if (weightiteration === maxWeightIteration && isStatWeights) {
             document.getElementById("weightloadbar").style.width =  100 + "%";
         }
         document.getElementById("loadbar").style.width =  100 + "%";
@@ -579,7 +579,7 @@ function statWeightLoop(){
     let olditerations = iterations;
     iterations = 20000;
     weightiteration = 0;
-    maxWeightIteration = iterations * 9;
+    maxWeightIteration = iterations * 13;
 
         
     loopSim().then(() => {
@@ -593,7 +593,6 @@ function statWeightLoop(){
     }).then(() => {
         // more followup work
         statweights.Agi = (avgDPS - basedps)/50;
-        console.log(statweights.Agi);
         custom = {str: 0,agi: -50,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
             haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
         calcBaseStats();
@@ -601,7 +600,6 @@ function statWeightLoop(){
     }).then(() => {
         // more followup work
         statweights.Agi = (Math.abs((avgDPS - basedps)/50)+statweights.Agi) / 2;
-        console.log(statweights.Agi);
         // ************** RAP *******************
         custom = {str: 0,agi: 0,int: 0,RAP: 100,rangehit: 0,rangecrit: 0,
             haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
@@ -617,7 +615,6 @@ function statWeightLoop(){
     }).then(() => {
         // more followup work
         statweights.RAP = (Math.abs((avgDPS - basedps)/100)+statweights.RAP) / 2;
-        console.log(statweights.RAP);
         // ************** RANGECRIT *******************
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 50,
             haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
@@ -633,7 +630,6 @@ function statWeightLoop(){
     }).then(() => {
         // more followup work
         statweights.RangeCrit = (Math.abs((avgDPS - basedps)/50)+statweights.RangeCrit) / 2;
-        console.log(statweights.RangeCrit);
         // ************** RANGEHIT *******************
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 10,rangecrit: 0,
             haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
@@ -649,7 +645,6 @@ function statWeightLoop(){
     }).then(() => { // save range hit
         // more followup work
         statweights.RangeHit = (Math.abs((avgDPS - basedps)/10)+statweights.RangeHit) / 2;
-        console.log(statweights.RangeHit);
         // ************** HASTE *******************
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
             haste: 100,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
@@ -665,7 +660,6 @@ function statWeightLoop(){
     }).then(() => {
         // more followup work
         statweights.Haste = (Math.abs((avgDPS - basedps)/100)+statweights.Haste) / 2;
-        console.log(statweights.Haste);
         // ************** ArP *******************
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
             haste: 0,arp: 100,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
@@ -681,7 +675,6 @@ function statWeightLoop(){
     }).then(() => {
         // more followup work
         statweights.ArP = (Math.abs((avgDPS - basedps)/100)+statweights.ArP) / 2;
-        console.log(statweights.ArP);
         // ************** MAP *******************
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
             haste: 0,arp: 0,MAP: 100,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
@@ -697,7 +690,6 @@ function statWeightLoop(){
     }).then(() => {
         // more followup work
         statweights.MAP = (Math.abs((avgDPS - basedps)/100)+statweights.MAP) / 2;
-        console.log(statweights.MAP);
         // ************** MELEE HIT *******************
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
             haste: 0,arp: 0,MAP: 0,meleehit: 10,meleecrit: 0,expertise: 0,mp5: 0};
@@ -705,7 +697,7 @@ function statWeightLoop(){
         return loopSim();
     }).then(() => {
         // more followup work
-        statweights.MAP = Math.max((avgDPS - basedps) / 10, 0);
+        statweights.MeleeHit = Math.max((avgDPS - basedps) / 10, 0);
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
             haste: 0,arp: 0,MAP: 0,meleehit: -10,meleecrit: 0,expertise: 0,mp5: 0};
         calcBaseStats();
@@ -713,6 +705,67 @@ function statWeightLoop(){
     }).then(() => {
         // more followup work
         statweights.MeleeHit = (Math.abs((avgDPS - basedps)/10)+statweights.MeleeHit) / 2;
+        // ************** MELEE CRIT *******************
+        custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
+            haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 50,expertise: 0,mp5: 0};
+        calcBaseStats();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        statweights.MeleeCrit = Math.max((avgDPS - basedps) / 50, 0);
+        custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
+            haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: -50,expertise: 0,mp5: 0};
+        calcBaseStats();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        statweights.MeleeCrit = (Math.abs((avgDPS - basedps)/50)+statweights.MeleeCrit) / 2;
+        // ************** EXPERTISE *******************
+        custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
+            haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 20,mp5: 0};
+        calcBaseStats();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        statweights.Expertise = Math.max((avgDPS - basedps) / 20, 0);
+        custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
+            haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: -20,mp5: 0};
+        calcBaseStats();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        statweights.Expertise = (Math.abs((avgDPS - basedps)/20)+statweights.Expertise) / 2;
+        // ************** MP5 *******************
+        custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
+            haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 50};
+        calcBaseStats();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        statweights.MP5 = Math.max((avgDPS - basedps) / 50, 0);
+        custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
+            haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: -50};
+        calcBaseStats();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        statweights.MP5 = (Math.abs((avgDPS - basedps)/50)+statweights.MP5) / 2;
+        // ************** INTELLECT *******************
+        custom = {str: 0,agi: 0,int: 50,RAP: 0,rangehit: 0,rangecrit: 0,
+            haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
+        calcBaseStats();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        statweights.Int = Math.max((avgDPS - basedps) / 50, 0);
+        custom = {str: 0,agi: 0,int: -50,RAP: 0,rangehit: 0,rangecrit: 0,
+            haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
+        calcBaseStats();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        statweights.Int = (Math.abs((avgDPS - basedps)/50)+statweights.Int) / 2;
+        // ************* RESET AND DISPLAY ****************
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
             haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
         console.log(statweights);

--- a/js/simulation.js
+++ b/js/simulation.js
@@ -1,5 +1,7 @@
 var iterations = 10000;
 var currentiteration = 0;
+var weightiteration = 0;
+var maxWeightIteration = 0;
 var loopcheck = 0;
 var minfighttimer = 243;
 var maxfighttimer = 245;
@@ -136,6 +138,7 @@ function loopSim() {
 
 function loopSimHelper(callback, isStatWeights) {
     currentiteration++;
+    if (isStatWeights) { weightiteration++;}
     if (currentiteration === iterations) {
         combatlogRun = true;
     } else {combatlogRun = false;}
@@ -143,13 +146,18 @@ function loopSimHelper(callback, isStatWeights) {
     sumdmg += totaldmgdone;
     sumpetdmg += petdmgdone;
     sumduration += totalduration;
-    
+
     if (currentiteration < iterations) {
         let visualcheck = currentiteration / 100;
 
         if (visualcheck > loopcheck){
             loopcheck++;
             setTimeout(() => loopSimHelper(callback, isStatWeights), 0);
+            if (isStatWeights) {
+
+                let loadweightbar = (weightiteration / maxWeightIteration) * 100;
+                document.getElementById("weightloadbar").style.width =  loadweightbar + "%";
+            }
             let loadpercent = (currentiteration / iterations) * 100;
             document.getElementById("loadbar").style.width =  loadpercent + "%";
             displayDPSResults();
@@ -159,7 +167,9 @@ function loopSimHelper(callback, isStatWeights) {
         }
     }
     else if (currentiteration === iterations){
-        
+        if (weightiteration === maxWeightIteration) {
+            document.getElementById("weightloadbar").style.width =  100 + "%";
+        }
         document.getElementById("loadbar").style.width =  100 + "%";
         
         if (!isStatWeights) {
@@ -179,11 +189,15 @@ function finalResults() {
     for (let prop in debuff_uptimes){
         debuff_uptimes[prop] = (debuffs[prop].uptime / sumduration * 100).toFixed(2);
     }
+    for (let prop in partybuff_uptimes){
+        partybuff_uptimes[prop] = (partybuffs[prop].uptime / sumduration * 100).toFixed(2);
+    }
 
     damageResults();
     //console.log(pet);
     console.log(buff_uptimes);
     console.log(debuff_uptimes);
+    console.log(partybuff_uptimes);
     console.log(currentMana);
 
     function standardError(x, u_x) {
@@ -239,7 +253,7 @@ function runSim() {
 
     initializeSpells();
     ResetAuras();
-    debuffInitializer();
+    intervalAuraInitializer();
 
     while (totalduration < fightduration){
 
@@ -547,79 +561,158 @@ problematic cases: raptor + arcane, multi + arcane + raptor
 	return "autoshot";
 }
 
-var statweights = { Str: 0, Agi: 0.947, Int: 0, RAP: 0.428, rangehit: 0.91, rangecrit: 0.782, 
-    Haste: 0.779, ArP: 0.161, MAP: 0, meleehit: 0, meleecrit: 0, Expertise: 0, MP5: 0, Hit:0.91, Crit:0.782,
-    relentless:20.35, beasttamer: 41.11, bonusdmg: 0.75
+var statweights = { Str: 0, Agi: 0.947, Int: 0, RAP: 0.428, RangeHit: 0.91, RangeCrit: 0.782, 
+    Haste: 0.779, ArP: 0.161, MAP: 0, MeleeHit: 0, MeleeCrit: 0, Expertise: 0, MP5: 0, Hit:0.91, Crit:0.782,
+    relentless:20.35, beasttamer: 22.11, dmgbonus: 0.75, rangedmgbonus: 0.75
 }
 
 function statWeightLoop(){
     isStatWeights = true;
-    statweights = { Str: 0, Agi: 0, Int: 0, RAP: 0, rangehit: 0, rangecrit: 0, 
-        haste: 0, arp: 0, MAP: 0, meleehit: 0, meleecrit: 0, expertise: 0, mp5: 0
+    useAverages = true;
+
+    statweights = { Str: 0, Agi: 0, Int: 0, RAP: 0, RangeHit: 0, RangeCrit: 0, 
+        Haste: 0, ArP: 0, MAP: 0, MeleeHit: 0, MeleeCrit: 0, Expertise: 0, MP5: 0, Hit:0, Crit:0,
+        relentless:0, beasttamer: 0, dmgbonus: 0, rangedmgbonus: 0
     }
     let basedps = 0;
     let performance1 = performance.now(); // test debug time check
     let olditerations = iterations;
     iterations = 20000;
+    weightiteration = 0;
+    maxWeightIteration = iterations * 9;
 
+        
     loopSim().then(() => {
         basedps = avgDPS;
-        custom = {str: 0,agi: 10,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
+        // ************** AGI *******************
+        custom = {str: 0,agi: 50,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
+            haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
+        calcBaseStats();
+        iterations = 10000;
+        return loopSim();       
+    }).then(() => {
+        // more followup work
+        statweights.Agi = (avgDPS - basedps)/50;
+        console.log(statweights.Agi);
+        custom = {str: 0,agi: -50,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
             haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
         calcBaseStats();
         return loopSim();
-    }).then(() => { // save agi
+    }).then(() => {
         // more followup work
-        statweights.agi = (avgDPS - basedps) / 10;
-        custom = {str: 0,agi: 0,int: 0,RAP: 10,rangehit: 0,rangecrit: 0,
+        statweights.Agi = (Math.abs((avgDPS - basedps)/50)+statweights.Agi) / 2;
+        console.log(statweights.Agi);
+        // ************** RAP *******************
+        custom = {str: 0,agi: 0,int: 0,RAP: 100,rangehit: 0,rangecrit: 0,
             haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
         calcBaseStats();
         return loopSim();
-    }).then(() => { // save RAP
+    }).then(() => {
         // more followup work
-        statweights.RAP = (avgDPS - basedps) / 10;
-        custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 10,
+        statweights.RAP = Math.max((avgDPS - basedps) / 100, 0);
+        custom = {str: 0,agi: 0,int: 0,RAP: -100,rangehit: 0,rangecrit: 0,
             haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
         calcBaseStats();
         return loopSim();
-    }).then(() => { // save range crit
+    }).then(() => {
         // more followup work
-        statweights.rangecrit = (avgDPS - basedps) / 10;
+        statweights.RAP = (Math.abs((avgDPS - basedps)/100)+statweights.RAP) / 2;
+        console.log(statweights.RAP);
+        // ************** RANGECRIT *******************
+        custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 50,
+            haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
+        calcBaseStats();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        statweights.RangeCrit = Math.max((avgDPS - basedps) / 50, 0);
+        custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: -50,
+            haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
+        calcBaseStats();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        statweights.RangeCrit = (Math.abs((avgDPS - basedps)/50)+statweights.RangeCrit) / 2;
+        console.log(statweights.RangeCrit);
+        // ************** RANGEHIT *******************
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 10,rangecrit: 0,
+            haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
+        calcBaseStats();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        statweights.RangeHit = Math.max((avgDPS - basedps) / 10, 0);
+        custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: -10,rangecrit: 0,
             haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
         calcBaseStats();
         return loopSim();
     }).then(() => { // save range hit
         // more followup work
-        statweights.rangehit = (avgDPS - basedps) / 10;
+        statweights.RangeHit = (Math.abs((avgDPS - basedps)/10)+statweights.RangeHit) / 2;
+        console.log(statweights.RangeHit);
+        // ************** HASTE *******************
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
             haste: 100,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
         calcBaseStats();
         return loopSim();
-    }).then(() => { // save haste
+    }).then(() => {
         // more followup work
-        statweights.haste = (avgDPS - basedps) / 10;
+        statweights.Haste = Math.max((avgDPS - basedps) / 100, 0);
+        custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
+            haste: -100,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
+        calcBaseStats();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        statweights.Haste = (Math.abs((avgDPS - basedps)/100)+statweights.Haste) / 2;
+        console.log(statweights.Haste);
+        // ************** ArP *******************
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
             haste: 0,arp: 100,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
         calcBaseStats();
         return loopSim();
-    }).then(() => { // save arp
+    }).then(() => {
         // more followup work
-        statweights.arp = (avgDPS - basedps) / 10;
+        statweights.ArP = Math.max((avgDPS - basedps) / 100, 0);
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
-            haste: 0,arp: 0,MAP: 10,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
+            haste: 0,arp: -100,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
         calcBaseStats();
         return loopSim();
-    }).then(() => { // save MAP
+    }).then(() => {
         // more followup work
-        statweights.MAP = (avgDPS - basedps) / 10;
+        statweights.ArP = (Math.abs((avgDPS - basedps)/100)+statweights.ArP) / 2;
+        console.log(statweights.ArP);
+        // ************** MAP *******************
+        custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
+            haste: 0,arp: 0,MAP: 100,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
+        calcBaseStats();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        statweights.MAP = Math.max((avgDPS - basedps) / 100, 0);
+        custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
+            haste: 0,arp: 0,MAP: -100,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
+        calcBaseStats();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        statweights.MAP = (Math.abs((avgDPS - basedps)/100)+statweights.MAP) / 2;
+        console.log(statweights.MAP);
+        // ************** MELEE HIT *******************
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
             haste: 0,arp: 0,MAP: 0,meleehit: 10,meleecrit: 0,expertise: 0,mp5: 0};
         calcBaseStats();
         return loopSim();
-    }).then(() => { // save hit
+    }).then(() => {
         // more followup work
-        statweights.meleehit = (avgDPS - basedps) / 10;
+        statweights.MAP = Math.max((avgDPS - basedps) / 10, 0);
+        custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
+            haste: 0,arp: 0,MAP: 0,meleehit: -10,meleecrit: 0,expertise: 0,mp5: 0};
+        calcBaseStats();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        statweights.MeleeHit = (Math.abs((avgDPS - basedps)/10)+statweights.MeleeHit) / 2;
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
             haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
         console.log(statweights);
@@ -629,6 +722,10 @@ function statWeightLoop(){
         displayDPSResults();
         displayStatWeights();
         iterations = olditerations;
+        useAverages = false;
+        isStatWeights = false;
+        statweights.Crit = statweights.RangeCrit + statweights.MeleeCrit;
+        statweights.Hit = statweights.RangeHit + statweights.MeleeHit;
         console.log("*****************");
     })
 

--- a/js/spells.js
+++ b/js/spells.js
@@ -159,8 +159,7 @@ function multiShotCalc(range_wep, combatRAP) {
 
 function arcaneShotCalc(range_wep, combatRAP) {
 
-    let arcanemod = 1;
-    let shotDmg = (combatRAP * 0.15 + SPELLS.arcaneshot.rankdmg) * range_wep.basedmgmod * combatdmgmod * arcanemod;
+    let shotDmg = (combatRAP * 0.15 + SPELLS.arcaneshot.rankdmg) * range_wep.basedmgmod * combatdmgmod * magdmgmod;
     return shotDmg;
 }
 

--- a/js/statCalculator.js
+++ b/js/statCalculator.js
@@ -119,7 +119,7 @@ function getMetagemBonuses(usedMeta, gemsUsed) {
   Object.entries(GEMS).filter(([, gemData]) => gemData.meta === 'Y')
     .forEach(([gemId, gemData]) => {
       const metaBonus = gemData.activation(Number(gemId) === usedMeta ? gemsUsed : noGems)
-      Object.entries(metaBonus).forEach(([bonus, val]) => {
+      Object.entries(metaBonus.bonus).forEach(([bonus, val]) => {
         if (bonus === 'aura') result.auras[gemId] = val
         else if (bonus === 'stats') sumStats(val, result.stats)
         else result.special[bonus] = val
@@ -173,7 +173,7 @@ function getStatsFromGems(gear) {
     if (isBonusFulfilled && gearPiece.socketBonus) sumStats(gearPiece.socketBonus, accStats)
     return accStats
   }, {})
-
+  gemsTotalsEquipped = gemCount
   const result = getMetagemBonuses(usedMeta, gemCount)
   sumStats(stats, result.stats)
 

--- a/js/statCalculator.js
+++ b/js/statCalculator.js
@@ -11,7 +11,6 @@ function sumStats(src, dst, statModifier = st => st) {
 
 /** Auxiliar function to add two special objects.*/
 function addSpecial(src, dst) {
-  console.log(src, dst)
 
   Object.entries(src).forEach(([k,v])=> {
     if (k === 'incWeapDmg') dst[k] = (dst[k] || 0) + v
@@ -19,7 +18,6 @@ function addSpecial(src, dst) {
     else dst[k] = v
   })
 
-  console.log(dst)
 }
 
 /** Auxiliar function to add two aura objects. Will throw error if an aura appears in both objects. */

--- a/js/ui.js
+++ b/js/ui.js
@@ -75,19 +75,19 @@ function displayDPSResults(){
 }
 
 function displayStatWeights(){
-    document.getElementsByClassName('weight-name')[0].innerHTML = statweights.Str.toFixed(2);
-    document.getElementsByClassName('weight-name')[1].innerHTML = statweights.Agi.toFixed(2);
-    document.getElementsByClassName('weight-name')[2].innerHTML = statweights.Int.toFixed(2);
-    document.getElementsByClassName('weight-name')[3].innerHTML = statweights.MP5.toFixed(2);
-    document.getElementsByClassName('weight-name')[4].innerHTML = statweights.RAP.toFixed(2);
-    document.getElementsByClassName('weight-name')[5].innerHTML = statweights.rangehit.toFixed(2);
-    document.getElementsByClassName('weight-name')[6].innerHTML = statweights.rangecrit.toFixed(2);
-    document.getElementsByClassName('weight-name')[7].innerHTML = statweights.Haste.toFixed(2);
-    document.getElementsByClassName('weight-name')[8].innerHTML = statweights.ArP.toFixed(2);
-    document.getElementsByClassName('weight-name')[9].innerHTML = statweights.MAP.toFixed(2);
-    document.getElementsByClassName('weight-name')[10].innerHTML = statweights.meleehit.toFixed(2);
-    document.getElementsByClassName('weight-name')[11].innerHTML = statweights.meleecrit.toFixed(2);
-    document.getElementsByClassName('weight-name')[12].innerHTML = statweights.Expertise.toFixed(2);
+    document.getElementsByClassName('weight-name')[0].innerHTML = statweights.Str.toFixed(3);
+    document.getElementsByClassName('weight-name')[1].innerHTML = statweights.Agi.toFixed(3);
+    document.getElementsByClassName('weight-name')[2].innerHTML = statweights.Int.toFixed(3);
+    document.getElementsByClassName('weight-name')[3].innerHTML = statweights.MP5.toFixed(3);
+    document.getElementsByClassName('weight-name')[4].innerHTML = statweights.RAP.toFixed(3);
+    document.getElementsByClassName('weight-name')[5].innerHTML = statweights.RangeHit.toFixed(3);
+    document.getElementsByClassName('weight-name')[6].innerHTML = statweights.RangeCrit.toFixed(3);
+    document.getElementsByClassName('weight-name')[7].innerHTML = statweights.Haste.toFixed(3);
+    document.getElementsByClassName('weight-name')[8].innerHTML = statweights.ArP.toFixed(3);
+    document.getElementsByClassName('weight-name')[9].innerHTML = statweights.MAP.toFixed(3);
+    document.getElementsByClassName('weight-name')[10].innerHTML = statweights.MeleeHit.toFixed(3);
+    document.getElementsByClassName('weight-name')[11].innerHTML = statweights.MeleeCrit.toFixed(3);
+    document.getElementsByClassName('weight-name')[12].innerHTML = statweights.Expertise.toFixed(3);
 }
 // initialize stats display
 displayStats();
@@ -208,17 +208,27 @@ function removeZeros(){
     filteredbuffs = buffslist.filter(filterById);
 }
 
-function submitImportData() {
+function submitImportData(type) {
 
     let importedgear = document.getElementById("importdata").value;
-    
+    let newgear = {};
+
     try {
-        let importdata = JSON.parse(importedgear);
-        let newgear = importFrom70U(importdata);
-        console.log(newgear);
+        if (type == '70U') {
+            newgear = importFrom70U(JSON.parse(importedgear));
+            newgear.gear.ammo.id = gear.ammo.id;
+
+            gear = newgear.gear;
+        } else if (type == 'WA') {
+            newgear = importFromWA(importedgear);
+            newgear.ammo.id = gear.ammo.id;
+
+            gear = newgear;
+        }
+        
+        
         // initialize ammo before re-writing
-        newgear.gear.ammo.id = gear.ammo.id;
-        gear = newgear.gear;
+        
 
         document.getElementById("importdata").value = '';
         document.getElementById("confirmimport").innerHTML = "Successfully Imported!";
@@ -229,6 +239,31 @@ function submitImportData() {
         console.log(err);
     }
     
+}
+
+function exportSavedDataStorage() {
+    JSON.stringify(localStorage)
+}
+
+function importSavedDataStorage() {
+
+    let importeddata = document.getElementById("importdata").value;
+    let newstorage = JSON.parse(importeddata);
+    try {
+        
+        for (let key in newstorage) {
+            localStorage[key] = newstorage[key];
+        }
+
+        document.getElementById("importdata").value = '';
+        document.getElementById("confirmimport").innerHTML = "Successfully Imported!";
+        fetchData();
+        selectedOptionsResults();
+    }
+    catch(err){
+        document.getElementById("confirmimport").innerHTML = "Failed to import.. Check copied data and try again.";
+        console.log(err);
+    }
 }
 
 // called each time buffs change to filter zeros, get, recalc, and display them

--- a/js/ui.js
+++ b/js/ui.js
@@ -347,7 +347,7 @@ function selectGearlist() {
     console.log(gear);
     selectedOptionsResults();
 }
-function debuffSettings(){
+function auraUptimeSettings(){
     let hmuptime = document.getElementById("hmuptime").value;
     let hmbonus = document.getElementById("hmbonus").selected;
     let ewuptime = document.getElementById("ewuptime").value;
@@ -364,6 +364,9 @@ function debuffSettings(){
     let misuptime = document.getElementById("misuptime").value;
     let coeuptime = document.getElementById("coeuptime").value;
     let coebonus = document.getElementById("coebonus").selected;
+    let unluptime = document.getElementById("unlrageuptime").value;
+    let ferocuptime = document.getElementById("ferocuptime").value;
+    let ferocstacks = document.getElementById("ferocstacks").value;
 
     debuffs.hm.uptime_g = parseInt(hmuptime);
     debuffs.hm.improved = hmbonus ? true : false;
@@ -381,6 +384,9 @@ function debuffSettings(){
     debuffs.bloodfrenzy.uptime_g = parseInt(bfuptime);
     debuffs.curseofele.uptime_g = parseInt(coeuptime);
     debuffs.curseofele.improved = coebonus ? true : false;
+    partybuffs.unleashedrage.uptime_g = parseInt(unluptime);
+    partybuffs.ferociousinsp.uptime_g = parseInt(ferocuptime);
+    partybuffs.ferociousinsp.stacks = parseInt(ferocstacks);
     storeData();
 }
 


### PR DESCRIPTION
Main Items
- Added Unleashed Rage and Ferocious Inspiration from party members, with stacks for F.I.
- added functionality for curse of elements and misery
- Expanded Sim EP to fully sim EP weights. Takes some time to run in order to be accurate

Improvements
- expanded import option to be able to accept 70U data, in-game weakaura data, or exported websim data
- added locations for every ranged weapon
- Added Apolyon, the Soul-Render and Stanchion of Primal Instinct
- added preferred gems temp data for calculating DPS for items with sockets
- added DPS estimates for the following:
  - Meta Gem bonuses
  - Beast-Tamer's shoulders
  - Weightstones/sharp stones
  - Mainhand DPS if weaving
  - Ranged DPS as if frenching

- added check for socket DPS to include metagem for head slot
- added meta gem requirements display: Greyed out if not met, green if met
- added Ferocious inspiration and unleashed rage to pet calcs
- added Ferocious inspiration and unleasehd rage to player calcs

Bug Fixes
- fixed alignment issues with images
- fixed issue with clickable containers only partially clickable
- Fixed incorrect IDs, icons, and quality for the following:
  - Shadowed Gauntlets of Paroxysm
  - Sha'tari Marksman's Gloves
  - Shadow-walker's Cord
  - Shadowstalker's Sash

- fixed an issue where uncommon gems were showing as common
- Fixed the quality color of all epic gems to properly be epic
- fixed an issue with racial crit not applying to bows and guns
- fixed an issue with function names conflicting
- fixed an issue with arcane shot not being buffed by misery/coe

Misc.
- changed phase for the following items:
  - Dory's Embrace
  - Hauberk of the War Bringers
  - Scaled Drakeskin Chestguard
  - Tunic of the Dark Hour
  - Nyn'jah's Tabi Boots
  - Handgrips of Assassination
  - Trickster's Stickyfingers
  - Gauntlets of Rapidity
  - Shifting Camouflage pants
  - Leggings of the Pursuit
  - Hardened Stone Shard
  - Vanir's Right Fist of Brutality
  - Swift Blade of Uncertainty
  - The Mutilator
  - War-feathered Loop
  - Belt of the Silent Path
  - Steadying Bracers
  - Master Assassin Wristwraps

- added comments on several functions for readability
- disabled links to gear planner/group eval for now.
- renamed some functions and settings area to make a little more sense -> "Debuffs" to "Aura Uptime instead" with the addition of unleashed rage and ferocious insp.
- added disclaimer to gear tabs for DPS values being just estimates
- removed all common gems (if you're really wanting white gems.. just LOL)
- removed many old level 60 ranged weps from the weapons list, keeping Nerubian, Rhok, and Ashjre'thul
- expanded stat weights to include all stats in the stats list
- made load bar for stat weights