### PR TITLE
Update misc fixes and readiness

### DIFF
--- a/js/auras.js
+++ b/js/auras.js
@@ -649,7 +649,7 @@ function intervalAuraInitializer(){
  * steps and are applied potentially during a step. A timer of 30 would start at 29.9 on the next step.
  */
 function IntervalAuraHandler(){
-    if(debuffs.hm.timer <= 0 || debuffs.hm.inactive) {debuffs.hm.stacks = 0;} // sets stacks to 0 when inactive
+    if(debuffs.hm.timer <= 0 || debuffs.hm.inactive && (debuffs.hm.uptime_g < 98)) {debuffs.hm.stacks = 0;} // sets stacks to 0 when inactive
     if((debuffs.hm.timer <= 0) && (debuffs.hm.uptime_g > 0)) { debuffs.hm.timer += IntervalAuraSetTime("hm","debuff"); } // sets the timer to inactive or active
     
     if((debuffs.exposeweakness.timer <= 0) && (talents.exp_weakness === 0 && debuffs.exposeweakness.uptime_g > 0)) { 
@@ -725,13 +725,14 @@ function IntervalAuraSetTime(name,type){
             //console.log(timer);
         }
         else if (partybuffs[name].refresh_ct > partybuffs[name].full_refresh){
-            timer = partybuffs[name].part_refresh_dur;
+            timer = (partybuffs[name].part_refresh_dur == 0) ? partybuffs[name].duration : partybuffs[name].part_refresh_dur;
             partybuffs[name].inactive = false;
             //console.log(timer);
         }
     } else {
         if(debuffs[name].uptime_g === 100){
             debuffs[name].inactive = true;
+            //console.log(name)
         }
         if(debuffs[name].inactive){debuffs[name].refresh_ct++;}
         if(debuffs[name].refresh_ct === debuffs[name].full_refresh && debuffs[name].inactive){ 
@@ -750,7 +751,7 @@ function IntervalAuraSetTime(name,type){
             //console.log(timer);
         }
         else if (debuffs[name].refresh_ct > debuffs[name].full_refresh){
-            timer = debuffs[name].part_refresh_dur;
+            timer = (debuffs[name].part_refresh_dur == 0) ? debuffs[name].duration : debuffs[name].part_refresh_dur;
             debuffs[name].inactive = false;
             //console.log(timer);
         }

--- a/js/auras.js
+++ b/js/auras.js
@@ -5,6 +5,8 @@ var racialenable = false;
 var beastenable = false;
 var temp_oil = false;
 
+var readiness = {enable:false, cooldown: 0, basecd: 300};
+var queueReadiness = false;
 var auras = {
     // actives
     drums: {enable:true, timer:0, cooldown:0,basecd:120, duration:30, uptime:0, type:'battle', offset:0},// coded
@@ -193,6 +195,8 @@ function initializeAuras() {
     rapidcd = 300 - talents.rapid_killing * 60;
     auras.rapid.basecd = rapidcd;
 
+    readiness.enable = (talents.readiness > 0) ? true : false;
+
     return;
  }
  function ResetAuras(){
@@ -269,6 +273,7 @@ function initializeAuras() {
     partybuffs.ferociousinsp.timer = 0;
 
     sharedtrinketcd = 0;
+    readiness.cooldown = 0;
 
     return;
  }
@@ -325,6 +330,8 @@ function updateAuras(steptime) {
     if(auras.tenacity.cooldown > 0)           { auras.tenacity.cooldown = Math.max(auras.tenacity.cooldown - steptime,0); }
     if(auras.righteous.cooldown > 0)          { auras.righteous.cooldown = Math.max(auras.righteous.cooldown - steptime,0); }
     if(auras.shattered.cooldown > 0)          { auras.shattered.cooldown = Math.max(auras.shattered.cooldown - steptime,0); }
+    if(readiness.cooldown > 0)                { readiness.cooldown = Math.max(readiness.cooldown - steptime,0); }
+    
     return;   
  }
 
@@ -788,7 +795,7 @@ function onUseSpellCheck(){
         }
     }
     let rapidcost = Math.floor(100 * beastwithinreduc);
-    if(auras.rapid.enable && auras.rapid.cooldown === 0 && currentMana >= rapidcost){
+    if(auras.rapid.enable && auras.rapid.cooldown === 0 && (currentMana >= rapidcost) && auras.rapid.timer == 0){
         auras.rapid.timer = (auras.rapid.cooldown === 0) ? auras.rapid.duration : auras.rapid.timer; // set timer
         auras.rapid.cooldown = (auras.rapid.timer === auras.rapid.duration) ? auras.rapid.basecd: auras.rapid.cooldown; // set cd
         if(combatlogRun) {
@@ -875,6 +882,19 @@ function onUseSpellCheck(){
         if(combatlogRun) {
             combatlogarray[combatlogindex] = steptimeend.toFixed(3) + " - Player gains Tenacity";
             combatlogindex++;
+        }
+    }
+
+    if (readiness.enable && (readiness.cooldown == 0) && auras.rapid.cooldown > 0) {
+        if (SPELLS.multishot.enable && SPELLS.multishot.cd > 5) {
+            queueReadiness = true;
+            
+        }
+        else if (!SPELLS.multishot.enable && SPELLS.steadyshot.cd > 0) {
+            queueReadiness = true;
+            
+        }
+        else { queueReadiness = false;
         }
     }
 }

--- a/js/data/gear.js
+++ b/js/data/gear.js
@@ -2601,7 +2601,7 @@ const FEET = {
         socketBonus: {
             Stam: 3
         },
-        Phase: 4,
+        Phase: 5,
         icon: "inv_boots_07",
         quality: "Epic"
     }
@@ -6854,7 +6854,7 @@ const MELEE_WEAPONS = {
         icon: "inv_weapon_hand_12",
         quality: "Epic"
     },
-    29962: {
+    31422: {
         name: "Heartless",
         stats: {
             Stam: 30,
@@ -7210,11 +7210,11 @@ const MELEE_WEAPONS = {
         icon: "inv_weapon_shortblade_03",
         quality: "Rare"
     },
-    31422: {
+    29962: {
         name: "Heartrazor",
         stats: {
-            Agi: 18,
-            Stam: 25
+            Agi: 20,
+            Stam: 30
         },
         Location: "The Eye",
         type: "dagger",

--- a/js/pet.js
+++ b/js/pet.js
@@ -91,7 +91,7 @@ function petStatsCalc(){
         beasttamers_dmg = 1.02;
         beasttamers_crit = 2;
     };
-    pet.dmgmod = PetHappiness * talents.unleash_fury * PETS[selectedPet].dmgmod * racialmod * beasttamers_dmg;
+    pet.dmgmod = PetHappiness * talents.unleash_fury * PETS[selectedPet].dmgmod * racialmod * beasttamers_dmg * selectedbuffs.special.impSancAura;
 
     pet.str = Math.floor((PetBaseStr + (selectedbuffs.stats.Str || 0) + (petconsumestats.Str || 0)) * selectedbuffs.special.kingsMod);
     pet.agi = Math.floor((PetBaseAgi + (selectedbuffs.stats.Agi || 0) + (petconsumestats.Agi || 0)) * selectedbuffs.special.kingsMod);

--- a/js/player.js
+++ b/js/player.js
@@ -342,7 +342,7 @@ function initialize(){
    petStatsCalc();
    initializeWeps();
    initializeAuras();
-   
+   getHitData(); // used for gear display, simple formula to set hit cap goal
 }
 
 function initializeWeps() {

--- a/js/player.js
+++ b/js/player.js
@@ -296,7 +296,8 @@ function calcBaseStats() {
   MeleeHitRating = hitrating + custom.meleehit;
 
   RangeHitRating = hitrating + (currentgear.stats.RangeHit || 0) + custom.rangehit;
-   let hit = BaseHitChance + talents.surefooted + BuffStats.HitChance;
+   let racialhit = (selectedRace == 2) ? 1 : 0;
+   let hit = BaseHitChance + talents.surefooted + BuffStats.HitChance + racialhit;
   MeleeHitChance = hit + MeleeHitRating / HitRatingRatio; // need dual wield condition
   RangeHitChance = hit + RangeHitRating / HitRatingRatio;
 

--- a/js/player.js
+++ b/js/player.js
@@ -334,8 +334,8 @@ function initialize(){
    checkWeaponType();
    currentgear = getStatsFromGear(gear);
    addGear();
-   console.log("current gear: ");
-   console.log(currentgear);
+   //console.log("current gear: ");
+   //console.log(currentgear);
    addBuffs();
    calcBaseStats();
    petStatsCalc();

--- a/js/simulation.js
+++ b/js/simulation.js
@@ -784,3 +784,293 @@ function statWeightLoop(){
 
       
 }
+
+function trinketSimLoop(){
+    isStatWeights = true;
+    useAverages = true;
+
+    //let basedps = 0;
+    let performance1 = performance.now(); // test debug time check
+    let olditerations = iterations;
+    iterations = 10000;
+    weightiteration = 0;
+    maxWeightIteration = iterations * 20;
+    let oldtrink1 = gear.trinket1;
+    let oldtrink2 = gear.trinket2;
+
+    // initialize trinket baseline
+    gear.trinket1 = { id: 23835 };
+    gear.trinket2 = { id: 23835 };
+    let basedps = 0;
+    let DPSdiff = [];
+    let loopnum = 0;
+    initialize();
+    let trinketlist = [
+        {id: 21670, name: "Badge of the Swarmguard" },
+        {id: 23041, name: "Slayer's Crest" },
+        {id: 23206, name: "Mark of the Champion" },
+        {id: 24128, name: "Figurine - Nightseye Panther" },
+        {id: 28034, name: "Hourglass of the Unraveller" },
+        {id: 28121, name: "Icon of Unyielding Courage" },
+        {id: 28288, name: "Abacus of Violent Odds" },
+        {id: 28579, name: "Romulo's Poison Vial" },
+        {id: 28830, name: "Dragonspine Trophy" },
+        {id: 29383, name: "Bloodlust Brooch" },
+        {id: 30627, name: "Tsunami Talisman" },
+        {id: 31856, name: "Darkmoon Card: Crusade" },
+        {id: 32487, name: "Ashtongue Talisman of Swiftness" },
+        {id: 32505, name: "Madness of the Betrayer" },
+        {id: 32654, name: "Crystalforged Trinket" },
+        {id: 32658, name: "Badge of Tenacity" },
+        {id: 33831, name: "Berserker's Call" },
+        {id: 34427, name: "Blackened Naaru Sliver" },
+        {id: 35702, name: "Figurine - Shadowsong Panther" }
+
+    ];
+    loopSim().then(() => {
+        basedps = avgDPS;
+        // ************** AGI *******************
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        initialize();
+        return loopSim();       
+    }).then(() => {
+        // more followup work
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+
+        // ************** RAP *******************
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+
+        // ************** RANGECRIT *******************
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+
+        // ************** RANGEHIT *******************
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        initialize();
+        return loopSim();
+    }).then(() => { // save range hit
+        // more followup work
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        // ************** HASTE *******************
+
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        // ************** ArP *******************
+
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        // ************** MAP *******************
+
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        // ************** MELEE HIT *******************
+
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        // ************** MELEE CRIT *******************
+
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        loopnum++;
+        gear.trinket1 = { id: trinketlist[loopnum].id };
+        console.log(gear.trinket1)
+        console.log("begin " + loopnum);
+        console.log(DPSdiff);
+        // ************** EXPERTISE *******************
+
+        initialize();
+        return loopSim();
+    }).then(() => {
+        // more followup work
+        
+        DPSdiff[loopnum] = { dps: (avgDPS - basedps), name: trinketlist[loopnum].name };
+        // more followup work
+
+        // ************* RESET AND DISPLAY ****************
+        gear.trinket1 = oldtrink1;
+        gear.trinket2 = oldtrink2;
+        initialize();
+        let performance2 = performance.now(); // test debug time check
+        executecodetime = (performance2 - performance1) / 1000; // milliseconds convert to sec
+        displayDPSResults();
+        //displayStatWeights();
+        console.log(DPSdiff);
+        iterations = olditerations;
+        useAverages = false;
+        isStatWeights = false;
+
+        console.log("*****************");
+    })
+
+      
+}

--- a/js/simulation.js
+++ b/js/simulation.js
@@ -657,13 +657,13 @@ function statWeightLoop(){
         // more followup work
         statweights.RangeCrit = (Math.abs((avgDPS - basedps)/50)+statweights.RangeCrit) / 2;
         // ************** RANGEHIT *******************
-        custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 10,rangecrit: 0,
+        custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: -10,rangecrit: 0,
             haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
         calcBaseStats();
         return loopSim();
     }).then(() => {
         // more followup work
-        statweights.RangeHit = Math.max((avgDPS - basedps) / 10, 0);
+        statweights.RangeHit = Math.max((basedps - avgDPS) / 10, 0);
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: -10,rangecrit: 0,
             haste: 0,arp: 0,MAP: 0,meleehit: 0,meleecrit: 0,expertise: 0,mp5: 0};
         calcBaseStats();
@@ -718,12 +718,12 @@ function statWeightLoop(){
         statweights.MAP = (Math.abs((avgDPS - basedps)/100)+statweights.MAP) / 2;
         // ************** MELEE HIT *******************
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
-            haste: 0,arp: 0,MAP: 0,meleehit: 10,meleecrit: 0,expertise: 0,mp5: 0};
+            haste: 0,arp: 0,MAP: 0,meleehit: -10,meleecrit: 0,expertise: 0,mp5: 0};
         calcBaseStats();
         return loopSim();
     }).then(() => {
         // more followup work
-        statweights.MeleeHit = Math.max((avgDPS - basedps) / 10, 0);
+        statweights.MeleeHit = Math.max((basedps - avgDPS) / 10, 0);
         custom = {str: 0,agi: 0,int: 0,RAP: 0,rangehit: 0,rangecrit: 0,
             haste: 0,arp: 0,MAP: 0,meleehit: -10,meleecrit: 0,expertise: 0,mp5: 0};
         calcBaseStats();

--- a/js/spells.js
+++ b/js/spells.js
@@ -10,6 +10,7 @@ var SPELLS = {
 
 };
 
+// for referencing spell names in combatlog
 SPELL_MAPPER = {
     autoshot: "Auto Shot",
     steadyshot: 'Steady Shot',
@@ -85,8 +86,8 @@ function initializeSpells(){
     SPELLS.steadyshot.cd = 0;
     SPELLS.multishot.cd = 0.5;
     SPELLS.arcaneshot.cd = 0.5;
-    SPELLS.raptorstrike.cd = 4; // set to 4 for initial delay for melee
-    SPELLS.melee.cd = 4; // set to 4 for initial delay for melee
+    SPELLS.raptorstrike.cd = 4; // set to 4 for initial delay for melee due to running in
+    SPELLS.melee.cd = 4; // set to 4 for initial delay for melee due to running in
     //SPELLS.aimedshot.cd = 0;
     // set pet spell CDs to 0
     PET_SPELLS[0].cd = 0;
@@ -101,8 +102,15 @@ function updateSpellCDs(spell,petspell) {
     SPELLS.multishot.cd = (spell === 'multishot') ? 10 : Math.max(SPELLS.multishot.cd - steptime, 0);
     SPELLS.arcaneshot.cd = (spell === 'arcaneshot') ? (6 - talents.imp_arc_shot) : Math.max(SPELLS.arcaneshot.cd - steptime, 0);
     //SPELLS.aimedshot.cd = Math.max(SPELLS.aimedshot.cd - steptime, 0);
-
-	if(spell === 'raptorstrike'){
+    
+    if(spell === 'readiness'){ // set spell cd's to 0
+        SPELLS.steadyshot.cd = 0;
+        SPELLS.multishot.cd = 0;
+        SPELLS.arcaneshot.cd = 0;
+        SPELLS.raptorstrike.cd = (SPELLS.melee.cd == 0) ? 0 : SPELLS.melee.cd;
+        //SPELLS.aimedshot.cd = 0;
+    }
+	else if(spell === 'raptorstrike'){
 		SPELLS.melee.cd = meleespeed;
 		SPELLS.raptorstrike.cd = 6;
 	}


### PR DESCRIPTION
- Added Readiness to 0/20/41 SV talent builds, resets rapid fire and all relevant spells with a 1s GCD. Casts after Multi GCD ends, or if no multi selected after steady's GCD ends, recasts rapid when timer ends after first use.
- Fixed stats for Heartrazor
- Fixed itemid's for Heartless and Heartrazor
- Fixed issue where debuffs set to 100% would not properly refresh/apply
- Adjusted HM to not refresh at 98% or above causing loss of stacks. Instead just delays initial cast
- Fixed phase for Sunrage Treads
- added dps estimate for Band of the Eternal Champion for gear lists
- added imp Sanctity Aura to pet DPS
- Fixed an issue with Draenei hit racial missing from player if Draenei race selected
- Added function for debugging with startStepOnly