### PR TITLE
sim update 5_20 mana graph and several minor changes

### DIFF
--- a/BERT/bert.js
+++ b/BERT/bert.js
@@ -1,0 +1,129 @@
+
+var base_weapon_speed = 2.9
+var melee_weapon_speed = 3.4
+var weave_time = .4
+var haste = 1.15
+var talents = {
+    imp_arc_shot: 0
+}
+var automulti_cast_time = .5 / haste;
+var steady_cast_time = 1.5 / haste;
+var cast_sequence = ["auto", "steady", "multi", "auto", "steady", "auto", "steady", "arcane", "auto", "steady", "auto", "steady", "auto", "steady"]
+var sixx_sequence = ['auto', 'steady', 'raptor', 'multi', 'auto', 'steady', 'auto', 'steady', 'melee', 'arcane', 'auto', 'steady', 'auto', 'steady']
+let range_speed = base_weapon_speed / haste;
+let melee_speed = melee_weapon_speed / haste;
+
+var actions = {
+
+    "auto":   { dmg: 1400, cast: automulti_cast_time, activecd: 0, cd: (base_weapon_speed - .5) / haste, depends_on: "None"},
+    "steady": { dmg: 1500, cast: steady_cast_time,  activecd: 0, cd:  0, depends_on: "GCD"},
+    "multi":  { dmg: 1600, cast: automulti_cast_time,  activecd: 0, cd:   10, depends_on: "GCD"},
+    "arcane": { dmg: 800,  cast: 0, activecd: 0, cd: 6, depends_on: "GCD"},
+    "melee":  { dmg: 1200, cast: weave_time, activecd: 0, cd: melee_weapon_speed, depends_on: "None"},
+    "raptor": { dmg: 2000, cast: weave_time, activecd: 0, cd: 6, depends_on: "melee"},
+    "GCD":    { dmg: 0,    cast: 0, activecd: 0, cd: 1.5, depends_on: "None"},
+
+}
+
+function spell_cds(spell,step) {
+    actions.auto.activecd = (spell === 'auto') ? (range_speed - actions.auto.cast) : Math.max(actions.auto.activecd - step, 0);
+    actions.steady.activecd = (spell === 'steady') ? (1.5 - actions.steady.cast) : Math.max(actions.steady.activecd - step, 0);
+    actions.multi.activecd = (spell === 'multi') ? 10 : Math.max(actions.multi.activecd - step, 0);
+    actions.arcane.activecd = (spell === 'arcane') ? (6 - talents.imp_arc_shot) : Math.max(actions.arcane.activecd - step, 0);
+	if(spell === 'raptor'){
+		actions.melee.activecd = melee_weapon_speed;
+		actions.raptor.activecd = 6;
+	}
+	else if(spell === 'melee'){
+		actions.melee.activecd = melee_weapon_speed;
+		actions.raptor.activecd = Math.max(actions.melee.activecd, actions.raptor.activecd);
+	}
+	else{
+		actions.melee.activecd = Math.max(actions.melee.activecd - step, 0);
+		actions.raptor.activecd = Math.max(actions.raptor.activecd - step, 0);
+	}
+
+    actions.GCD.activecd = Math.max(actions.GCD.activecd - step, 0);
+    //console.log(spell + " " + step)
+    //console.log(actions.auto);
+    //console.log(actions.steady);
+    //console.log("*******************")
+}
+
+function RotationCalc(array){
+    let rotation = {
+        time: 0,
+        damage: 0,
+        cast_log: [],
+        first_cast: {},
+        delay: 0
+    }
+
+    solveRotation(array,rotation);
+    rotation.delay = delay_to_repeat(rotation); 
+    rotation.time = rotation.time + rotation.delay;
+    let dmgresult = dps(rotation);
+    console.log("Input Array");
+    console.log(array);
+    console.log("Total Time => "+rotation.time);
+    console.log("Delay to repeat => "+rotation.delay);
+    console.log("DPS => " + dmgresult)
+    console.log("***************");
+}
+
+function dps(rotation) {
+    return rotation.damage / (rotation.time)
+}
+
+function solveRotation(cast_array,rotation) {
+    let i = 0;
+    let length = cast_array.length;
+    let spellcast = '';
+    //let newrotation = {};
+    for (i=0; i < length; i++) {
+        spellcast = cast_array[i];
+        stepRotation(spellcast, rotation);
+        //newrotation = JSON.parse(JSON.stringify(rotation));
+        //console.log(newrotation);
+    }
+}
+
+function stepRotation(spellcast, rotation) {
+    rotation.damage += actions[spellcast].dmg
+
+    let step = actions[spellcast].activecd;
+    if (actions[spellcast].depends_on != "None") {
+        step = Math.max(step, actions[actions[spellcast].depends_on].activecd)
+    }
+
+    rotation.time += step
+    rotation.cast_log.push([rotation.time, spellcast + "_started"])
+    spell_cds('', step)
+
+    if (rotation.first_cast[spellcast] == null) {
+        rotation.first_cast[spellcast] = rotation.time
+    }
+    if (actions[spellcast].depends_on != "None") {
+        if (rotation.first_cast[actions[spellcast].depends_on] == null) {
+            rotation.first_cast[actions[spellcast].depends_on] = rotation.time
+        }
+        actions[actions[spellcast].depends_on].activecd = actions[actions[spellcast].depends_on].cd
+    }
+    rotation.time += actions[spellcast].cast
+    let stepend = actions[spellcast].cast
+    rotation.cast_log.push([rotation.time, spellcast + "_finished"])
+    spell_cds(spellcast,stepend)
+
+}
+
+function delay_to_repeat(rotation) {
+       let delay = 0;
+       let delay_obj = {}; 
+       
+       for (spellcast in rotation.first_cast) {
+            delay_obj[spellcast] = Math.max(actions[spellcast].activecd - rotation.first_cast[spellcast], 0)
+            delay = Math.max(delay, delay_obj[spellcast])
+       }
+
+    return delay;
+}

--- a/BERT/index.html
+++ b/BERT/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html style="font-size: 16px;" lang="en">
+<head>
+    <script class="u-script" type="text/javascript" src="bert.js"></script>
+</head>

--- a/index.html
+++ b/index.html
@@ -1043,6 +1043,9 @@
     <div class="chartBox">
       <canvas id="histogram"></canvas>
     </div>
+    <div class="chartBox">
+      <canvas id="line-chart"></canvas>
+    </div>
     <hr><!--generated series of <p></p> for displaying combat log data-->
     <div id="combatlog" class="label-7">N/A</div>
   

--- a/js/data/gear.js
+++ b/js/data/gear.js
@@ -1758,7 +1758,7 @@ const CHESTS = {
             Hit: 30,
             Haste: 38
         },
-        Location: "Sunwell",
+        Location: "Crafting",
         sockets: [
             "Yellow",
             "Red",
@@ -8746,7 +8746,319 @@ const MELEE_WEAPONS = {
         Phase: 5,
         icon: "inv_weapon_shortblade_78",
         quality: "Epic"
-    }
+    },
+    34996: {
+        name: "Brutal Gladiator's Cleaver",
+        stats: {
+            Stam: 31,
+            MAP: 38,
+            RAP: 38,
+            Crit: 22,
+            Hit: 9,
+            Resil: 12,
+            ArP: 49
+        },
+        Location: "Arena Reward",
+        type: "axe",
+        speed: 2.6,
+        mindmg: 196,
+        maxdmg: 365,
+        hand: "One",
+        Phase: 5,
+        icon: "inv_axe_1h_blacksmithing_02",
+        quality: "Epic"
+    },
+    34997: {
+        name: "Brutal Gladiator's Decapitator",
+        stats: {
+            Stam: 66,
+            MAP: 100,
+            RAP: 100,
+            Crit: 50,
+            Hit: 19,
+            ArP: 98,
+            Resil: 33
+        },
+        Location: "Arena Reward",
+        type: "axe",
+        speed: 3.6,
+        mindmg: 404,
+        maxdmg: 606,
+        hand: "Two",
+        Phase: 5,
+        icon: "inv_axe_73",
+        quality: "Epic"
+    },
+    35015: {
+        name: "Brutal Gladiator's Greatsword",
+        stats: {
+            Stam: 66,
+            Str: 50,
+            Crit: 50,
+            Hit: 19,
+            ArP: 98,
+            Resil: 33
+        },
+        Location: "Arena Reward",
+        type: "sword",
+        speed: 3.6,
+        mindmg: 404,
+        maxdmg: 606,
+        hand: "Two",
+        Phase: 5,
+        icon: "inv_sword_116",
+        quality: "Epic"
+    },
+    35017: {
+        name: "Brutal Gladiator's Hacker",
+        stats: {
+            Stam: 31,
+            MAP: 38,
+            RAP: 38,
+            Crit: 22,
+            Hit: 9,
+            Resil: 12,
+            ArP: 49
+        },
+        Location: "Arena Reward",
+        type: "axe",
+        speed: 1.5,
+        mindmg: 113,
+        maxdmg: 211,
+        hand: "Off",
+        Phase: 5,
+        icon: "inv_axe_1h_blacksmithing_02",
+        quality: "Epic"
+    },
+    35308: {
+        name: "Brutal Gladiator's Left Ripper",
+        stats: {
+            Stam: 31,
+            MAP: 38,
+            RAP: 38,
+            Crit: 22,
+            Hit: 9,
+            Resil: 12,
+            ArP: 49
+        },
+        Location: "Arena Reward",
+        type: "fist",
+        speed: 1.5,
+        mindmg: 113,
+        maxdmg: 211,
+        hand: "Off",
+        Phase: 5,
+        icon: "inv_weapon_hand_15",
+        quality: "Epic"
+    },
+    35064: {
+        name: "Brutal Gladiator's Painsaw",
+        stats: {
+            Stam: 68,
+            MAP: 102,
+            RAP: 102,
+            Crit: 51,
+            Resil: 42
+        },
+        Location: "Arena Reward",
+        type: "polearm",
+        speed: 2.2,
+        mindmg: 247,
+        maxdmg: 371,
+        hand: "Two",
+        Phase: 5,
+        icon: "inv_weapon_halberd_20",
+        quality: "Epic"
+    },
+    35072: {
+        name: "Brutal Gladiator's Quickblade",
+        stats: {
+            Stam: 31,
+            MAP: 38,
+            RAP: 38,
+            Crit: 22,
+            Hit: 9,
+            Resil: 12,
+            ArP: 49
+        },
+        Location: "Arena Reward",
+        type: "sword",
+        speed: 1.5,
+        mindmg: 113,
+        maxdmg: 211,
+        hand: "Off",
+        Phase: 5,
+        icon: "inv_sword_114",
+        quality: "Epic"
+    },
+    35076: {
+        name: "Brutal Gladiator's Right Ripper",
+        stats: {
+            Stam: 31,
+            MAP: 38,
+            RAP: 38,
+            Crit: 22,
+            Hit: 9,
+            Resil: 12,
+            ArP: 49
+        },
+        Location: "Arena Reward",
+        type: "fist",
+        speed: 2.6,
+        mindmg: 196,
+        maxdmg: 365,
+        hand: "Main",
+        Phase: 5,
+        icon: "inv_weapon_hand_15",
+        quality: "Epic"
+    },
+    35093: {
+        name: "Brutal Gladiator's Shanker",
+        stats: {
+            Stam: 31,
+            MAP: 38,
+            RAP: 38,
+            Crit: 22,
+            Hit: 9,
+            Resil: 12,
+            ArP: 49
+        },
+        Location: "Arena Reward",
+        type: "dagger",
+        speed: 1.8,
+        mindmg: 155,
+        maxdmg: 233,
+        hand: "One",
+        Phase: 5,
+        icon: "inv_weapon_shortblade_75",
+        quality: "Epic"
+    },
+    35095: {
+        name: "Brutal Gladiator's Shiv",
+        stats: {
+            Stam: 31,
+            MAP: 38,
+            RAP: 38,
+            Crit: 22,
+            Hit: 9,
+            Resil: 12,
+            ArP: 49
+        },
+        Location: "Arena Reward",
+        type: "dagger",
+        speed: 1.4,
+        mindmg: 105,
+        maxdmg: 197,
+        hand: "Off",
+        Phase: 5,
+        icon: "inv_weapon_shortblade_75",
+        quality: "Epic"
+    },
+    35101: {
+        name: "Brutal Gladiator's Slicer",
+        stats: {
+            Stam: 31,
+            MAP: 38,
+            RAP: 38,
+            Crit: 22,
+            Hit: 9,
+            Resil: 12,
+            ArP: 49
+        },
+        Location: "Arena Reward",
+        type: "sword",
+        speed: 2.6,
+        mindmg: 224,
+        maxdmg: 337,
+        hand: "One",
+        Phase: 5,
+        icon: "inv_sword_114",
+        quality: "Epic"
+    },
+    35058: {
+        name: "Brutal Gladiator's Mutilator",
+        stats: {
+            Stam: 31,
+            MAP: 38,
+            RAP: 38,
+            Crit: 22,
+            Hit: 9,
+            Resil: 12,
+            ArP: 49
+        },
+        Location: "Arena Reward",
+        type: "dagger",
+        speed: 1.8,
+        mindmg: 136,
+        maxdmg: 253,
+        hand: "Off",
+        Phase: 5,
+        icon: "inv_weapon_shortblade_75",
+        quality: "Epic"
+    },
+    35110: {
+        name: "Brutal Gladiator's Waraxe",
+        stats: {
+            Stam: 31,
+            MAP: 38,
+            RAP: 38,
+            Crit: 22,
+            Hit: 9,
+            Resil: 12,
+            ArP: 49
+        },
+        Location: "Arena Reward",
+        type: "axe",
+        speed: 2.6,
+        mindmg: 196,
+        maxdmg: 365,
+        hand: "Main",
+        Phase: 5,
+        icon: "inv_axe_1h_blacksmithing_02",
+        quality: "Epic"
+    },
+    34995: {
+        name: "Brutal Gladiator's Chopper",
+        stats: {
+            Stam: 31,
+            MAP: 38,
+            RAP: 38,
+            Crit: 22,
+            Hit: 9,
+            Resil: 12,
+            ArP: 49
+        },
+        Location: "Arena Reward",
+        type: "axe",
+        speed: 2.6,
+        mindmg: 196,
+        maxdmg: 365,
+        hand: "Off",
+        Phase: 5,
+        icon: "inv_axe_1h_blacksmithing_02",
+        quality: "Epic"
+    },
+    35037: {
+        name: "Brutal Gladiator's Left Render",
+        stats: {
+            Stam: 31,
+            MAP: 38,
+            RAP: 38,
+            Crit: 22,
+            Hit: 9,
+            Resil: 12,
+            ArP: 49
+        },
+        Location: "Arena Reward",
+        type: "fist",
+        speed: 2.6,
+        mindmg: 196,
+        maxdmg: 365,
+        hand: "Off",
+        Phase: 5,
+        icon: "inv_weapon_hand_15",
+        quality: "Epic"
+    },
 }
 
 const NECKS = {
@@ -10304,7 +10616,58 @@ const RANGED_WEAPONS = {
         icon: "inv_weapon_crossbow_26",
         quality: "Epic",
         Location: "Badge Reward"
-    }
+    },
+    35018: {
+        name: "Brutal Gladiator's Heavy Crossbow",
+        stats: {
+            Stam: 27,
+            RAP: 38,
+            Crit: 17,
+            Resil: 13
+        },
+        type: "Xbow",
+        mindmg: 234,
+        maxdmg: 351,
+        speed: 3,
+        Phase: 5,
+        icon: "inv_weapon_crossbow_26",
+        quality: "Epic",
+        Location: "Arena Reward"
+    },
+    35047: {
+        name: "Brutal Gladiator's Longbow",
+        stats: {
+            Stam: 27,
+            RAP: 38,
+            Crit: 17,
+            Resil: 13
+        },
+        type: "Bow",
+        mindmg: 234,
+        maxdmg: 351,
+        speed: 3,
+        Phase: 5,
+        icon: "inv_weapon_bow_31",
+        quality: "Epic",
+        Location: "Arena Reward"
+    },
+    35075: {
+        name: "Brutal Gladiator's Rifle",
+        stats: {
+            Stam: 27,
+            RAP: 38,
+            Crit: 17,
+            Resil: 13
+        },
+        type: "Gun",
+        mindmg: 234,
+        maxdmg: 351,
+        speed: 3,
+        Phase: 5,
+        icon: "inv_weapon_rifle_21",
+        quality: "Epic",
+        Location: "Arena Reward"
+    },
 }
 
 const RINGS = {

--- a/js/data/gems.js
+++ b/js/data/gems.js
@@ -1,6 +1,6 @@
 const GEMS = {
   22459: {
-      name: "Void Sphere",
+      name: "Void Sphere (+4 Resist)",
       colors: [
           "red",
           "yellow",
@@ -12,7 +12,7 @@ const GEMS = {
       icon: "inv_enchant_voidsphere"
   },
   23097: {
-      name: "Delicate Blood Garnet",
+      name: "Delicate Blood Garnet (+6 Agi)",
       colors: [
           "red"
       ],
@@ -24,7 +24,7 @@ const GEMS = {
       icon: "inv_misc_gem_bloodgem_02"
   },
   23100: {
-      name: "Glinting Flame Spessarite",
+      name: "Glinting Flame Spessarite (+3 Agi +3 Hit)",
       colors: [
           "red",
           "yellow"
@@ -38,7 +38,7 @@ const GEMS = {
       icon: "inv_misc_gem_flamespessarite_02"
   },
   23104: {
-      name: "Jagged Deep Peridot",
+      name: "Jagged Deep Peridot (+4 Stam +3 Crit)",
       colors: [
           "yellow",
           "blue"
@@ -52,7 +52,7 @@ const GEMS = {
       icon: "inv_misc_gem_deepperidot_02"
   },
   23106: {
-      name: "Dazzling Deep Peridot",
+      name: "Dazzling Deep Peridot (+3 Int +1 Mp5)",
       colors: [
           "yellow",
           "blue"
@@ -66,7 +66,7 @@ const GEMS = {
       icon: "inv_misc_gem_deepperidot_02"
   },
   23110: {
-      name: "Shifting Shadow Draenite",
+      name: "Shifting Shadow Draenite (+3 Agi +4 Stam)",
       colors: [
           "red",
           "blue"
@@ -80,7 +80,7 @@ const GEMS = {
       icon: "inv_misc_gem_ebondraenite_02"
   },
   23113: {
-      name: "Brilliant Golden Draenite",
+      name: "Brilliant Golden Draenite (+6 Int)",
       colors: [
           "yellow"
       ],
@@ -92,7 +92,7 @@ const GEMS = {
       icon: "inv_misc_gem_goldendraenite_02"
   },
   23116: {
-      name: "Rigid Golden Draenite",
+      name: "Rigid Golden Draenite (+6 Hit)",
       colors: [
           "yellow"
       ],
@@ -104,7 +104,7 @@ const GEMS = {
       icon: "inv_misc_gem_goldendraenite_02"
   },
   23118: {
-      name: "Solid Azure Moonstone",
+      name: "Solid Azure Moonstone (+9 Stam)",
       colors: [
           "blue"
       ],
@@ -116,7 +116,7 @@ const GEMS = {
       icon: "inv_misc_gem_azuredraenite_02"
   },
   23121: {
-      name: "Lustrous Azure Moonstone",
+      name: "Lustrous Azure Moonstone (+2 Mp5)",
       colors: [
           "blue"
       ],
@@ -128,7 +128,7 @@ const GEMS = {
       icon: "inv_misc_gem_azuredraenite_02"
   },
   24028: {
-      name: "Delicate Living Ruby",
+      name: "Delicate Living Ruby (+8 Agi)",
       colors: [
           "red"
       ],
@@ -140,7 +140,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_livingruby_03"
   },
   24031: {
-      name: "Bright Living Ruby",
+      name: "Bright Living Ruby (+16 AP)",
       colors: [
           "red"
       ],
@@ -153,7 +153,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_livingruby_03"
   },
   24033: {
-      name: "Solid Star of Elune",
+      name: "Solid Star of Elune (+12 Stam)",
       colors: [
           "blue"
       ],
@@ -165,7 +165,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_starofelune_03"
   },
   24037: {
-      name: "Lustrous Star of Elune",
+      name: "Lustrous Star of Elune (+3 Mp5)",
       colors: [
           "blue"
       ],
@@ -177,7 +177,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_starofelune_03"
   },
   24047: {
-      name: "Brilliant Dawnstone",
+      name: "Brilliant Dawnstone (+8 Int)",
       colors: [
           "yellow"
       ],
@@ -189,7 +189,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_dawnstone_03"
   },
   24048: {
-      name: "Smooth Dawnstone",
+      name: "Smooth Dawnstone (+8 Crit)",
       colors: [
           "yellow"
       ],
@@ -201,7 +201,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_dawnstone_03"
   },
   24051: {
-      name: "Rigid Dawnstone",
+      name: "Rigid Dawnstone (+8 Hit)",
       colors: [
           "yellow"
       ],
@@ -213,7 +213,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_dawnstone_03"
   },
   24053: {
-      name: "Mystic Dawnstone",
+      name: "Mystic Dawnstone (+8 Resil)",
       colors: [
           "yellow"
       ],
@@ -225,7 +225,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_dawnstone_03"
   },
   24055: {
-      name: "Shifting Nightseye",
+      name: "Shifting Nightseye (+4 Agi +6 Stam)",
       colors: [
           "red",
           "blue"
@@ -239,7 +239,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_nightseye_03"
   },
   24061: {
-      name: "Glinting Noble Topaz",
+      name: "Glinting Noble Topaz (+4 Agi +4 Hit)",
       colors: [
           "red",
           "yellow"
@@ -253,7 +253,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_nobletopaz_03"
   },
   24065: {
-      name: "Dazzling Talasite",
+      name: "Dazzling Talasite (+4 Int +2 Mp5)",
       colors: [
           "yellow",
           "blue"
@@ -267,7 +267,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_talasite_03"
   },
   24067: {
-      name: "Jagged Talasite",
+      name: "Jagged Talasite (+6 Stam +4 Crit)",
       colors: [
           "yellow",
           "blue"
@@ -281,7 +281,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_talasite_03"
   },
   25894: {
-      name: "Swift Skyfire Diamond",
+      name: "Swift Skyfire Diamond (+24 AP +8% Speed)",
       meta: "Y",
       activation: gemsUsed => {
         const bonus = { swift_metagem_run_speed_increase: 1.00 }
@@ -301,7 +301,7 @@ const GEMS = {
       desc: "1 Red, 2 Yellow"
   },
   25895: {
-      name: "Enigmatic Skyfire Diamond",
+      name: "Enigmatic Skyfire Diamond (+12 Crit)",
       meta: "Y",
       activation: gemsUsed => {
         const bonus = {}
@@ -318,7 +318,7 @@ const GEMS = {
       desc: "More Red than Yellow"
   },
   25896: {
-      name: "Powerful Earthstorm Diamond",
+      name: "Powerful Earthstorm Diamond (+18 Stam)",
       meta: "Y",
       activation: gemsUsed => {
         const bonus = {}
@@ -335,7 +335,7 @@ const GEMS = {
       desc: "3 Blue"
   },
   25901: {
-      name: "Insightful Earthstorm Diamond",
+      name: "Insightful Earthstorm Diamond (+12 Int)",
       meta: "Y",
       activation: gemsUsed => {
         const bonus = {}
@@ -352,7 +352,7 @@ const GEMS = {
       desc: "2 Red, 2 Yellow, 2 Blue"
   },
   27679: {
-      name: "Sublime Mystic Dawnstone",
+      name: "Sublime Mystic Dawnstone (+10 Resil)",
       colors: [
           "yellow"
       ],
@@ -365,7 +365,7 @@ const GEMS = {
       icon: "inv_misc_gem_topaz_01"
   },
   27809: {
-      name: "Barbed Deep Peridot",
+      name: "Barbed Deep Peridot (+3 Stam +4 Crit)",
       colors: [
           "yellow",
           "blue"
@@ -380,7 +380,7 @@ const GEMS = {
       icon: "inv_misc_gem_deepperidot_01"
   },
   28290: {
-      name: "Smooth Golden Draenite",
+      name: "Smooth Golden Draenite (+6 Crit)",
       colors: [
           "yellow"
       ],
@@ -392,7 +392,7 @@ const GEMS = {
       icon: "inv_misc_gem_goldendraenite_02"
   },
   28361: {
-      name: "Mighty Blood Garnet",
+      name: "Mighty Blood Garnet (+14 AP)",
       colors: [
           "red"
       ],
@@ -406,7 +406,7 @@ const GEMS = {
       icon: "inv_misc_gem_bloodstone_02"
   },
   28556: {
-      name: "Swift Windfire Diamond",
+      name: "Swift Windfire Diamond (+20 AP)",
       meta: "Y",
       activation: gemsUsed => {
         const bonus = { swift_metagem_run_speed_increase: 1.00 }
@@ -425,7 +425,7 @@ const GEMS = {
       desc: "2 Yellow, 1 Red"
   },
   28595: {
-      name: "Bright Blood Garnet",
+      name: "Bright Blood Garnet (+12 AP)",
       colors: [
           "red"
       ],
@@ -438,7 +438,7 @@ const GEMS = {
       icon: "inv_misc_gem_bloodgem_02"
   },
   30549: {
-      name: "Shifting Tanzanite",
+      name: "Shifting Tanzanite (+5 Agi +6 Stam)",
       colors: [
           "red",
           "blue"
@@ -453,7 +453,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_nightseye_03"
   },
   30550: {
-      name: "Sundered Chrysoprase",
+      name: "Sundered Chrysoprase (+5 Crit +2 Mp5)",
       colors: [
           "yellow",
           "blue"
@@ -468,7 +468,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_talasite_03"
   },
   30553: {
-      name: "Pristine Fire Opal",
+      name: "Pristine Fire Opal (+10 AP +4 Hit)",
       colors: [
           "red",
           "yellow"
@@ -484,7 +484,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_nobletopaz_03"
   },
   30556: {
-      name: "Glinting Fire Opal",
+      name: "Glinting Fire Opal (+5 Agi +4 Hit)",
       colors: [
           "red",
           "yellow"
@@ -499,7 +499,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_nobletopaz_03"
   },
   30574: {
-      name: "Brutal Tanzanite",
+      name: "Brutal Tanzanite (+6 Stam +10 AP)",
       colors: [
           "red",
           "blue"
@@ -515,7 +515,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_nightseye_03"
   },
   30582: {
-      name: "Deadly Fire Opal",
+      name: "Deadly Fire Opal (+8 AP +5 Crit)",
       colors: [
           "red",
           "yellow"
@@ -531,7 +531,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_nobletopaz_03"
   },
   30583: {
-      name: "Timeless Chrysoprase",
+      name: "Timeless Chrysoprase (+6 Stam +5 Int)",
       colors: [
           "yellow",
           "blue"
@@ -546,7 +546,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_talasite_03"
   },
   30589: {
-      name: "Dazzling Chrysoprase",
+      name: "Dazzling Chrysoprase (+5 Int +2 Mp5)",
       colors: [
           "yellow",
           "blue"
@@ -561,7 +561,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_talasite_03"
   },
   30591: {
-      name: "Empowered Fire Opal",
+      name: "Empowered Fire Opal (+8 AP +5 Resil)",
       colors: [
           "red",
           "yellow"
@@ -577,7 +577,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_nobletopaz_03"
   },
   30592: {
-      name: "Steady Chrysoprase",
+      name: "Steady Chrysoprase (+6 Stam +5 Resil)",
       colors: [
           "yellow",
           "blue"
@@ -592,7 +592,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_talasite_03"
   },
   30602: {
-      name: "Jagged Chrysoprase",
+      name: "Jagged Chrysoprase (+6 Stam +5 Crit)",
       colors: [
           "yellow",
           "blue"
@@ -607,7 +607,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_talasite_03"
   },
   31118: {
-      name: "Pulsing Amethyst",
+      name: "Pulsing Amethyst (+6 Stam +10 AP)",
       colors: [
           "red",
           "blue"
@@ -623,7 +623,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_nightseye_03"
   },
   31862: {
-      name: "Balanced Shadow Draenite",
+      name: "Balanced Shadow Draenite (+4 Stam +6 AP)",
       colors: [
           "red",
           "blue"
@@ -638,7 +638,7 @@ const GEMS = {
       icon: "inv_misc_gem_ebondraenite_02"
   },
   31863: {
-      name: "Balanced Nightseye",
+      name: "Balanced Nightseye (+6 Stam +8 AP)",
       colors: [
           "red",
           "blue"
@@ -653,7 +653,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_nightseye_03"
   },
   31864: {
-      name: "Infused Shadow Draenite",
+      name: "Infused Shadow Draenite (+6 AP +1 Mp5)",
       colors: [
           "red",
           "blue"
@@ -668,7 +668,7 @@ const GEMS = {
       icon: "inv_misc_gem_ebondraenite_02"
   },
   31865: {
-      name: "Infused Nightseye",
+      name: "Infused Nightseye (+8 AP +2 Mp5)",
       colors: [
           "red",
           "blue"
@@ -683,7 +683,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_nightseye_03"
   },
   31868: {
-      name: "Wicked Noble Topaz",
+      name: "Wicked Noble Topaz (+8 AP +4 Crit)",
       colors: [
           "red",
           "yellow"
@@ -698,7 +698,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_nobletopaz_03"
   },
   31869: {
-      name: "Wicked Flame Spessarite",
+      name: "Wicked Flame Spessarite (+6 AP +3 Crit)",
       colors: [
           "red",
           "yellow"
@@ -713,7 +713,7 @@ const GEMS = {
       icon: "inv_misc_gem_flamespessarite_02"
   },
   32194: {
-      name: "Delicate Crimson Spinel",
+      name: "Delicate Crimson Spinel (+10 Agi)",
       colors: [
           "red"
       ],
@@ -725,7 +725,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_crimsonspinel_02"
   },
   32200: {
-      name: "Solid Empyrean Sapphire",
+      name: "Solid Empyrean Sapphire (+15 Stam)",
       colors: [
           "blue"
       ],
@@ -737,7 +737,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_empyreansapphire_02"
   },
   32202: {
-      name: "Lustrous Empyrean Sapphire",
+      name: "Lustrous Empyrean Sapphire (+4 Mp5)",
       colors: [
           "blue"
       ],
@@ -749,7 +749,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_empyreansapphire_02"
   },
   32204: {
-      name: "Brilliant Lionseye",
+      name: "Brilliant Lionseye (+10 Int)",
       colors: [
           "yellow"
       ],
@@ -761,7 +761,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_lionseye_02"
   },
   32205: {
-      name: "Smooth Lionseye",
+      name: "Smooth Lionseye (+10 Crit)",
       colors: [
           "yellow"
       ],
@@ -773,7 +773,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_lionseye_02"
   },
   32206: {
-      name: "Rigid Lionseye",
+      name: "Rigid Lionseye (+10 Hit)",
       colors: [
           "yellow"
       ],
@@ -785,7 +785,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_lionseye_02"
   },
   32209: {
-      name: "Mystic Lionseye",
+      name: "Mystic Lionseye (+10 Resil)",
       colors: [
           "yellow"
       ],
@@ -797,7 +797,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_lionseye_02"
   },
   32212: {
-      name: "Shifting Shadowsong Amethyst",
+      name: "Shifting Shadowsong Amethyst (+5 Agi +7 Stam)",
       colors: [
           "red",
           "blue"
@@ -811,7 +811,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_shadowsongamethyst_02"
   },
   32213: {
-      name: "Balanced Shadowsong Amethyst",
+      name: "Balanced Shadowsong Amethyst (+7 Stam +10 AP)",
       colors: [
           "red",
           "blue"
@@ -826,7 +826,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_shadowsongamethyst_02"
   },
   32214: {
-      name: "Infused Shadowsong Amethyst",
+      name: "Infused Shadowsong Amethyst (+10 AP +2 Mp5)",
       colors: [
           "red",
           "blue"
@@ -841,7 +841,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_shadowsongamethyst_02"
   },
   32220: {
-      name: "Glinting Pyrestone",
+      name: "Glinting Pyrestone (+5 Agi +5 Hit)",
       colors: [
           "red",
           "yellow"
@@ -855,7 +855,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_pyrestone_02"
   },
   32222: {
-      name: "Wicked Pyrestone",
+      name: "Wicked Pyrestone (+10 AP +5 Crit)",
       colors: [
           "red",
           "yellow"
@@ -870,7 +870,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_pyrestone_02"
   },
   32225: {
-      name: "Dazzling Seaspray Emerald",
+      name: "Dazzling Seaspray Emerald (+5 Int +2 Mp5)",
       colors: [
           "yellow",
           "blue"
@@ -884,7 +884,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_seasprayemerald_02"
   },
   32226: {
-      name: "Jagged Seaspray Emerald",
+      name: "Jagged Seaspray Emerald (+7 Stam +5 Crit)",
       colors: [
           "yellow",
           "blue"
@@ -898,7 +898,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_seasprayemerald_02"
   },
   32409: {
-      name: "Relentless Earthstorm Diamond",
+      name: "Relentless Earthstorm Diamond (+12 Crit +3% Crit Dmg)",
       meta: "Y",
       activation: gemsUsed => {
         const bonus = { relentless_metagem_crit_dmg_inc: 1.00 }
@@ -917,7 +917,7 @@ const GEMS = {
       desc: "2 Red, 2 Yellow, 2 Blue"
   },
   32410: {
-      name: "Thundering Skyfire Diamond",
+      name: "Thundering Skyfire Diamond (+240 Haste Proc)",
       meta: "Y",
       activation: gemsUsed => {
         const bonus = {}
@@ -941,7 +941,7 @@ const GEMS = {
       desc: "2 Red, 2 Yellow, 2 Blue"
   },
   32634: {
-      name: "Unstable Amethyst",
+      name: "Unstable Amethyst (+6 Stam +8 AP)",
       colors: [
           "red",
           "blue"
@@ -957,7 +957,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_shadowsongamethyst_01"
   },
   32635: {
-      name: "Unstable Peridot",
+      name: "Unstable Peridot (+6 Stam +4 Int)",
       colors: [
           "yellow",
           "blue"
@@ -972,7 +972,7 @@ const GEMS = {
       icon: "inv_misc_gem_deepperidot_03"
   },
   32637: {
-      name: "Unstable Citrine",
+      name: "Unstable Citrine (+8 AP +4 Crit)",
       colors: [
           "red",
           "yellow"
@@ -988,7 +988,7 @@ const GEMS = {
       icon: "inv_misc_gem_opal_01"
   },
   32640: {
-      name: "Potent Unstable Diamond",
+      name: "Potent Unstable Diamond (+24 AP)",
       meta: "Y",
       activation: gemsUsed => {
         const bonus = {}
@@ -1007,7 +1007,7 @@ const GEMS = {
       desc: "More Blue than Yellow"
   },
   33131: {
-      name: "Crimson Sun",
+      name: "Crimson Sun (+32 AP)",
       colors: [
           "red"
       ],
@@ -1021,7 +1021,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_crimsonspinel_02"
   },
   33135: {
-      name: "Falling Star",
+      name: "Falling Star (+18 Stam)",
       colors: [
           "blue"
       ],
@@ -1033,21 +1033,8 @@ const GEMS = {
       unique: true,
       icon: "inv_jewelcrafting_empyreansapphire_02"
   },
-  33138: {
-      name: "Mystic Bladestone",
-      colors: [
-          "yellow"
-      ],
-      stats: {
-          Resil: 12
-      },
-      Phase: 3,
-      quality: "Epic",
-      unique: true,
-      icon: "inv_jewelcrafting_lionseye_02"
-  },
   33143: {
-      name: "Stone of Blades",
+      name: "Stone of Blades (+12 Crit)",
       colors: [
           "yellow"
       ],
@@ -1060,7 +1047,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_lionseye_02"
   },
   33782: {
-      name: "Steady Talasite",
+      name: "Steady Talasite (+6 Stam +4 Resil)",
       colors: [
           "yellow",
           "blue"
@@ -1074,7 +1061,7 @@ const GEMS = {
       icon: "inv_jewelcrafting_talasite_03"
   },
   34256: {
-      name: "Charmed Amani Jewel",
+      name: "Charmed Amani Jewel (+15 Stam)",
       colors: [
           "blue"
       ],
@@ -1086,8 +1073,21 @@ const GEMS = {
       unique: true,
       icon: "inv_misc_gem_pearl_07"
   },
+  32197: {
+    name: "Bright Crimson Spinel (+20 AP)",
+    colors: [
+        "red"
+    ],
+    stats: {
+        MAP: 20,
+        RAP: 20
+    },
+    Phase: 3,
+    quality: "Epic",
+    icon: "inv_jewelcrafting_crimsonspinel_02"
+  },
   35487: {
-      name: "Bright Crimson Spinel",
+      name: "Bright Crimson Spinel (+20 AP)",
       colors: [
           "red"
       ],
@@ -1095,12 +1095,12 @@ const GEMS = {
           MAP: 20,
           RAP: 20
       },
-      Phase: 3,
+      Phase: 5,
       quality: "Epic",
       icon: "inv_jewelcrafting_crimsonspinel_02"
   },
   28362: {
-      name: "Bold Ornate Ruby",
+      name: "Bold Ornate Ruby (+20 AP)",
       colors: [
           "red"
       ],
@@ -1114,7 +1114,7 @@ const GEMS = {
       icon: "inv_misc_gem_ruby_02"
   },
   28363: {
-      name: "Inscribed Ornate Topaz",
+      name: "Inscribed Ornate Topaz (+10 AP +5 Crit)",
       colors: [
           "red",
           "yellow"
@@ -1130,7 +1130,7 @@ const GEMS = {
       icon: "inv_misc_gem_opal_01"
   },
   28119: {
-      name: "Smooth Ornate Dawnstone",
+      name: "Smooth Ornate Dawnstone (+10 Crit)",
       colors: [
           "yellow"
       ],
@@ -1141,5 +1141,19 @@ const GEMS = {
       quality: "Epic",
       unique: true,
       icon: "inv_misc_gem_topaz_01"
+  },
+  30565: {
+      name: "Assassin's Fire Opal (+6 Crit +5 Dodge)",
+      colors: [
+          "red",
+          "yellow"
+      ],
+      stats: {
+          Crit: 6
+      },
+      Phase: 1,
+      quality: "Epic",
+      unique: true,
+      icon: "inv_jewelcrafting_nobletopaz_03"
   }
 };

--- a/js/gearui.js
+++ b/js/gearui.js
@@ -105,6 +105,15 @@ document.getElementById("trinket1slot").addEventListener("click", function(){gea
 document.getElementById("trinket2slot").addEventListener("click", function(){gearModalDisplay("trinket2")}, false);
 document.getElementById("ammoslot").addEventListener("click", function(){gearModalDisplay("ammo")}, false);
 
+function updateAttachments(itemid, attachid) {
+    let attach = attachid;
+    
+    if (attach == 28421 || attach == 23529) {
+        attach = ((MELEE_WEAPONS[itemid].type == 'fist') || (MELEE_WEAPONS[itemid].type == 'staff')) ? 28421 : 23529;
+    }
+    return attach;
+}
+
 // select an item based on given itemid input, selected from a clicked row in the gear tbody
 function selectItem(itemid) {
     let ench = (!!gear[activeslot].enchant && gear[activeslot].enchant > 0) ? gear[activeslot].enchant : 0;
@@ -141,10 +150,7 @@ function selectItem(itemid) {
             if (ench == 27977 || ench == 42620 || ench == 27971 || ench == 27837) {
                 ench = (MELEE_WEAPONS[itemid].hand == 'Two') ? 27977 : 42620;
             }
-            // if attach is a stone, check if selected is fist then use weightstone, else use sharp stone
-            if (attach == 28421 || attach == 23529) {
-                attach = ((MELEE_WEAPONS[itemid].type == 'fist') || (MELEE_WEAPONS[itemid].type == 'staff')) ? 28421 : 23529;
-            }
+            attach = updateAttachments(itemid,attach);
             
             gear[activeslot] = { id: parseInt(itemid), gems: [], enchant: ench, attachment: attach };
             checkWeaponType();
@@ -159,10 +165,8 @@ function selectItem(itemid) {
         case 'offhand':
             console.log("you selected "+ itemid);
 
-            // if attach is a stone, check if selected is fist then use weightstone, else use sharp stone
-            if (attach == 28421 || attach == 23529) {
-                attach = ((MELEE_WEAPONS[itemid].type == 'fist')) ? 28421 : 23529;
-            }
+            attach = updateAttachments(itemid,attach);
+            
             gear[activeslot] = { id: parseInt(itemid), gems: [], enchant: 42620, attachment: attach };
         break;
         case 'range':

--- a/js/player.js
+++ b/js/player.js
@@ -899,7 +899,7 @@ function attackSpell(spell,spellcost) {
    magicproc(attack);
 
    if(combatlogRun) {
-      combatlogarray[combatlogindex] = playertimeend.toFixed(3) + " - Player " + SPELL_MAPPER[spell] + " " + RESULTARRAY[result] + " for " + done + ". RAP => " + combatRAP;
+      combatlogarray[combatlogindex] = playertimeend.toFixed(3) + " - Player " + SPELL_MAPPER[spell] + " " + RESULTARRAY[result] + " for " + done + ". RAP => " + combatRAP + ". Mana => " + currentMana;
       combatlogindex++;
    }
    return;
@@ -1050,7 +1050,7 @@ function procauto() {
 }
 /** handling for procs by steady only */
 function procsteady() {
-      // madness of the betrayer
+      // ashtongue
    if (auras.ashtongue.enable){
       let roll = rng10k(); 
       auras.ashtongue.timer = (roll <= auras.ashtongue.procchance * 100) ? auras.ashtongue.duration : auras.ashtongue.timer;

--- a/js/simulation.js
+++ b/js/simulation.js
@@ -82,6 +82,8 @@ var sumpetdmg = 0;
 var fightduration = 0;
 var combatlogarray = [];
 var combatlogindex = 0;
+var manalogarray = [];
+var manalogindex = 0;
 var filteredcombatlogarray = [];
 var combatlogRun = false;
 
@@ -223,6 +225,7 @@ function finalResults() {
         return Number(Math.floor(each_element / 5) * 5);
     });
     buildBuffUptimes();
+    buildManaData();
     buildData(newspread);
     createHistogram();
     console.log("*****************");
@@ -249,6 +252,8 @@ function runSim() {
     playerattackready = false;
     combatlogarray = [];
     combatlogindex = 0;
+    manalogarray = [];
+    manalogindex = 0;
     killcommand.ready = false;
 
     initializeSpells();
@@ -285,6 +290,11 @@ function runSim() {
         //console.log("step "+ steptime);
         petUpdateFocus();
         updateMana();
+
+        if((combatlogRun) && (playertimeend != prevtimeend)) {
+            manalogarray[manalogindex] = [playertimeend, currentMana];
+            manalogindex++;
+        }
         prevtimeend = steptimeend;
         totalduration = steptimeend;
         //console.log("total damage: " + totaldmgdone);

--- a/js/statCalculator.js
+++ b/js/statCalculator.js
@@ -13,7 +13,7 @@ function sumStats(src, dst, statModifier = st => st) {
 function addSpecial(src, dst) {
 
   Object.entries(src).forEach(([k,v])=> {
-    if (k === 'incWeapDmg') dst[k] = (dst[k] || 0) + v
+    if ((k === 'dmgbonus') || (k === 'rangedmgbonus')) dst[k] = (dst[k] || 0) + v
     else if (k === 'multishot_dmg_inc_ratio') dst[k] = dst[k] > 1 ? (dst[k] || 1) + v - 1 : v
     else dst[k] = v
   })
@@ -199,7 +199,7 @@ function getStatsFromEnchants(gear) {
     }
 
     return result
-  }, { stats: {}, special: { incWeapDmg: 0, moveSpeed: 1 }, auras: {} })
+  }, { stats: {}, special: { dmgbonus: 0, rangedmgbonus: 0, moveSpeed: 1 }, auras: {} })
 }
 
 /** Given the gear object, calculates stats, auras and special values obtained from enchants */
@@ -219,7 +219,7 @@ function getStatsFromAttachments(gear) {
     }
 
     return result
-  }, { stats: {}, special: { incWeapDmg: 0, moveSpeed: 1 }, auras: {} })
+  }, { stats: {}, special: { dmgbonus: 0, rangedmgbonus: 0, moveSpeed: 1 }, auras: {} })
 }
 
 /* Given the amount of pieces used for each set, calculates bonuses provided by each set.
@@ -261,9 +261,9 @@ function getStatsFromGearPieces(gear) {
       if (!ALLOWED_IN_MAINHAND.includes(gearPiece.hand)) throw new Error(`Tried to use "${gearPiece.name}" in ${type} but its not allowed.`)
       if (gearPiece.hand === 'Two' && gear.offhand) throw new Error(`Can't use a two-handed weapon and an offhand weapon!`)
     } else if (type === 'offhand' && !ALLOWED_IN_OFFHAND.includes(gearPiece.hand)) throw new Error(`Tried to use "${gearPiece.name}" in ${type} but its not allowed.`)
-    else if (type === 'ammo') {
-      if (gearPiece.type === 'arrow' && gearPiece.range?.type === 'Gun') throw new Error(`Tried to use arrows on a gun`)
-      else if (gearPiece.type === 'bullet' && gearPiece.range?.type !== 'Gun') throw new Error(`Tried to use bullets on a bow/x-bow`)
+    else if (type === 'ammo' && activeslot == 'ammo') {
+      if (gearPiece.type === 'arrow' && RANGED_WEAPONS[gear.range.id].type === 'Gun') throw new Error(`Using arrows with a gun`)
+      else if (gearPiece.type === 'bullet' && RANGED_WEAPONS[gear.range.id].type !== 'Gun') throw new Error(`Using bullets with a Bow/X-Bow`)
     }
 
 

--- a/js/stats.js
+++ b/js/stats.js
@@ -1,5 +1,7 @@
 var spreaddata = {};
 var uptimedata = {};
+var manadata = {};
+
 var actions = {
   auto: "Auto Shot",
   arcane: "Arcane Shot",
@@ -11,6 +13,38 @@ var actions = {
   kc: "Kill Command (Pet)",
   primary: "Primary (Pet)"
 };
+
+const AURA_MAPPER = {
+  drums: "Drums",
+  potion: "Potion",
+  abacus: "Haste (Abacus)",
+  lust: "Bloodlust",
+  rapid: "Rapid Fire",
+  berserk: "Berserking (Troll)",
+  unyieldingcourage: "Unyielding Courage",
+  bloodfury: "Bloodfury (Orc)",
+  swarmguard: "Insight of the Qiraji (Swarmguard)",
+  beastwithin: "The Beast Within",
+  tenacity: "Badge of Tenacity",
+  aptrink1: auras.aptrink1.name,
+  aptrink2: auras.aptrink2.name,
+  dragonspine: "Dragonspine Trophy",
+  imphawk: "Quick Shots (Imp Hawk)",
+  beastlord: "Beast Lord",
+  executioner: "Executioner",
+  mongoose: "Mongoose",
+  madness: "Forceful Strike (MotB)",
+  tsunami: "Fury of the Crashing Waves (TT)",
+  hourglass: "Rage of the Unraveler (HG)",
+  naarusliver: "Battle Trance (BNS)",
+  eternalchamp: "Band of the Eternal Champion",
+  donsantos: "Santo's Blessing",
+  mastertact: "Master Tactitian",
+  ashtongue: "Deadly Aim (Ash)",
+  dmccrusade: "Darkmoon Card: Crusade",
+  righteous: "Righteousness (Oil)",
+  shattered: "Light's Strength (Aldor)"
+}
 
 function buildData(spread){
 
@@ -60,6 +94,9 @@ function createHistogram(){
             title: {
               display:true,
               text: 'DPS',
+              font: {
+                size: 14,
+              },
               color: 'rgb(170,	211, 114)'
             }
           },
@@ -67,6 +104,9 @@ function createHistogram(){
             title: {
               display:true,
               text: 'Frequency',
+              font: {
+                size: 14,
+              },
               color: 'rgb(170,	211, 114)'
             },
             ticks: {
@@ -124,9 +164,89 @@ function createHistogram(){
         title: {
           display: true,
           text: 'Buff Uptimes',
+          font: {
+            size: 14,
+          },
           color: 'white'
+        },
+        tooltip: {
+          callbacks: {
+            title: function(d) {
+              return d[0].label;
+            },
+            label: function(d) {
+              return d.raw + " %";
+            }
+          }
         }
       }
+    },
+  });
+  managraph.destroy();
+  ctz = document.getElementById("line-chart").getContext('2d');
+  managraph = new Chart(ctz, {
+    type: 'line',
+    data: manadata,
+    options: {
+      elements: {
+        point:{
+            radius: 0
+        },
+      },
+      scales: {
+        x: {
+          title: {
+            display: true,
+            text: 'Time (s)',
+            font: {
+              size: 14,
+            },
+            color: 'white'
+          },
+          ticks: {
+            color: 'white',
+            callback: function(value) { return this.getLabelForValue(value).toFixed(0) }
+          },
+        },
+        y: {
+          min: 0,
+          max: Mana,
+          title: {
+            display:true,
+            text: 'Mana',
+            font: {
+              size: 14,
+            },
+            color: 'white'
+          },
+          ticks: {
+            color: 'white'
+          }
+        }
+      },
+      responsive: true,
+      plugins: {
+        legend: {
+          display: false,
+          position: 'right',
+        },
+        title: {
+          display: true,
+          text: 'Mana Usage on Final Iteration',
+          color: 'white'
+        },
+        tooltip: {
+          callbacks: {
+            title: function(tooltipItems, data) {
+              return '';
+            },
+            label: function(data) {
+              return data.raw + " Mana";
+              
+            }
+          }
+        },
+      },
     },
   });
 }
@@ -174,6 +294,7 @@ var histogram = new Chart(ctx, {
       }
   }
 });
+
 function buildBuffUptimes(){
 
   let filtereduptimes = Object.entries(buff_uptimes).filter(key => !key.includes('0.00'));
@@ -185,7 +306,7 @@ function buildBuffUptimes(){
   };
 
   for (key in filtereduptimes) {
-    uptimedata.labels.push(filtereduptimes[key][0]);
+    uptimedata.labels.push(AURA_MAPPER[filtereduptimes[key][0]]);
     data.push(filtereduptimes[key][1]);
   }
 
@@ -199,6 +320,7 @@ function buildBuffUptimes(){
   });
 
 }
+
 const barconfig = {
   type: 'bar',
   data: uptimedata,
@@ -227,6 +349,105 @@ const barconfig = {
 var cty = document.getElementById('horizontalbar').getContext('2d');
 var horizontalbar = new Chart(cty, barconfig);
 
+
+function buildManaData(){
+
+  let data = [];
+
+  manadata = {
+    labels: [],
+    datasets: []
+  };
+
+  let arrlength = manalogarray.length;
+
+  for (i=0; i < arrlength; i++) {
+    manadata.labels[i] = manalogarray[i][0];
+    data[i] = manalogarray[i][1];
+  }
+
+  manadata.datasets.push({
+    data: data,
+    borderColor: "#029ad1",
+    fill: false,
+  });
+
+}
+
+const lineconfig = {
+    type: 'line',
+    data: manadata,
+    options: {
+      elements: {
+        point:{
+            radius: 0
+        },
+      },
+      scales: {
+        x: {
+          title: {
+            display: true,
+            text: 'Time (s)',
+            font: {
+              size: 14,
+            },
+            color: 'white'
+          },
+          ticks: {
+            color: 'white',
+            callback: function(value) { return this.getLabelForValue(value).toFixed(0) }
+          },
+        },
+        y: {
+          min: 0,
+          max: Mana,
+          title: {
+            display:true,
+            text: 'Mana',
+            font: {
+              size: 14,
+            },
+            color: 'white'
+          },
+          ticks: {
+            color: 'white'
+          }
+        }
+      },
+      responsive: true,
+      plugins: {
+        legend: {
+          display: false,
+          position: 'right',
+        },
+        title: {
+          display: true,
+          text: 'Mana Usage on Final Iteration',
+          color: 'white'
+        },
+        tooltip: {
+          callbacks: {
+            title: function(tooltipItems, data) {
+              return '';
+            },
+            label: function(data) {
+              return data.raw + " Mana";
+              
+            }
+          }
+        },
+      },
+    },
+}
+
+var ctz = document.getElementById("line-chart").getContext('2d');
+var managraph = new Chart(ctz, lineconfig);
+
+
+
+// ***********************************************************************
+// ** STATS on abilities   
+// ***********************************************************************
 function damageResults(){
   simresults = {
       steady: {},

--- a/js/ui.js
+++ b/js/ui.js
@@ -232,6 +232,13 @@ function submitImportData(type) {
 
     let importedgear = document.getElementById("importdata").value;
     let newgear = {};
+    let attach = 0;
+
+    if (type == '70U') {
+        newgear = importFrom70U(JSON.parse(importedgear));
+    } else if (type == 'WA') {
+        newgear = importFromWA(importedgear);
+    }
 
     try {
         if (type == '70U') {
@@ -245,13 +252,26 @@ function submitImportData(type) {
 
             gear = newgear;
         }
+        // update imported gear to include attachments by default
+        if (!gear.mainhand.attachment) {
+            attach = updateAttachments(gear.mainhand.id, 28421);
+            gear.mainhand.attachment = attach;
+        }
+        if (!!gear.offhand && !gear.offhand.attachment) {
+            attach = updateAttachments(gear.offhand.id, 28421);
+            gear.offhand.attachment = attach;
+        }
 
         document.getElementById("importdata").value = '';
         document.getElementById("confirmimport").innerHTML = "Successfully Imported!";
         selectedOptionsResults();
     }
     catch(err){
-        //throw new Error("Failed to import: " + err)
+        if (type == '70U') {
+            throw new Error("Failed to import: " + newgear.gear.errors)
+        } else if (type == 'WA') {
+            throw new Error("Failed to import: " + newgear.errors)
+        }
     }
     
 }
@@ -298,18 +318,21 @@ function importSavedDataStorage() {
     let importeddata = document.getElementById("importdata").value;
     let newstorage = JSON.parse(importeddata);
     try {
-        
-        for (let key in newstorage) {
-            localStorage[key] = newstorage[key];
+        if (newstorage.savecheck) {
+            for (let key in newstorage) {
+                localStorage[key] = newstorage[key];
+            }
+    
+            document.getElementById("importdata").value = '';
+            document.getElementById("confirmimport").innerHTML = "Successfully Imported!";
+            fetchData();
+            selectedOptionsResults();
+        } else {
+            document.getElementById("confirmimport").innerHTML = "Failed to import.. Missing Data.";
         }
-
-        document.getElementById("importdata").value = '';
-        document.getElementById("confirmimport").innerHTML = "Successfully Imported!";
-        fetchData();
-        selectedOptionsResults();
     }
     catch(err){
-        console.log(err);
+        throw new Error("Failed to import: " + err);
     }
 }
 


### PR DESCRIPTION
- Adjusted Carapace of Sun and Shadow location
- Added Brutal Gladiator melee and ranged weapons to phase 5 gear
- Added stats text to gems for easy searching and browsing
- Fixed an issue with importing and failing to report the reason for an import not working
- Added a check for imports to automatically select attachments based on weapon imported (ignores oils for SWP atm)
- Partially fixed an issue with accidently "importing" local data that wasn't actually saved data, causing the localStorage to be corrupted and required a reset
- Added more descriptive names for auras on the bar graph in combat log window.
- Added mana usage graph for last iteration
- Increased font size of graph labels
- added % sign to aura uptimes for clarity on what the value is
- Fixed an issue where + damage wasn't stacking from attachments
- Fixed an issue where changing bow would give an error for ammo used. Still errors if changing ammo but not relevant if just swapping bows (ammo mostly just visual if dmg is same)
- Added mana display per ability cast in combat log
- Removed non-existent Mystic Bladestone gem (+12 Resil only on PTR ever)
- added Bright Crimson Spinel and fixed id of BoP version from SWP
- added Assassin's Fire Opal (+6 Crit +5 Dodge)